### PR TITLE
164 kcauto crash if combat module is disabled and pvp resets

### DIFF
--- a/kcauto/startup/kcauto.py
+++ b/kcauto/startup/kcauto.py
@@ -352,6 +352,7 @@ class Kcauto(object):
         
         if passive_only == True:
             #passive repair only, temporarily disable combat and pvp module
+            log_temp = Log.enabled
             Log.enabled = False
             combat_temp = com.combat.enabled
             com.combat.enabled = False
@@ -371,7 +372,7 @@ class Kcauto(object):
             #restore combat and pvp module status
             com.combat.enabled = combat_temp
             pvp.pvp.enabled = pvp_temp
-            Log.enabled = True 
+            Log.enabled = log_temp 
             
 
     def _run_fleetswitch_logic(self, context):

--- a/kcauto/startup/kcauto.py
+++ b/kcauto/startup/kcauto.py
@@ -352,10 +352,11 @@ class Kcauto(object):
         
         if passive_only == True:
             #passive repair only, temporarily disable combat and pvp module
+            Log.enabled = False
             combat_temp = com.combat.enabled
-            com.combat._enabled = False
+            com.combat.enabled = False
             pvp_temp = pvp.pvp.enabled
-            pvp.pvp._enabled = False
+            pvp.pvp.enabled = False
         
         if rep.repair.can_conduct_repairs:
             rep.repair.repair_ships()
@@ -368,8 +369,9 @@ class Kcauto(object):
             
         if passive_only == True:
             #restore combat and pvp module status
-            com.combat._enabled = combat_temp
-            pvp.pvp._enabled = pvp_temp
+            com.combat.enabled = combat_temp
+            pvp.pvp.enabled = pvp_temp
+            Log.enabled = True 
             
 
     def _run_fleetswitch_logic(self, context):

--- a/kcauto/util/logger.py
+++ b/kcauto/util/logger.py
@@ -17,9 +17,13 @@ class Log(ABC):
     CLR_END = '\033[0m'
 
     log_file = None
+    
+    _enabled = False
 
     @classmethod
     def init(cls):
+        
+        cls.enabled = True
 
         # Force stdout to use UTF-8
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
@@ -53,6 +57,19 @@ class Log(ABC):
         # YY/mm/dd H:M:S
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         cls.log_file = open( "log/" + dt_string + ".log", "w", encoding='utf-8')
+        
+    @property
+    def enabled(self):
+        """Indicates whether or not the module is enabled.
+        """
+        return self._enabled
+    
+    @enabled.setter
+    def enabled(cls, value):
+        if type(value) is not bool:
+            raise TypeError(
+                f"Enabled setting for module Log is not a bool.")
+        cls._enabled = value
 
     @staticmethod
     def _log_format(msg):
@@ -73,6 +90,9 @@ class Log(ABC):
         Args:
             msg (str): log message.
         """
+        if not cls.enabled:
+            return
+        
         print(
             f"{cls.CLR_MSG}{cls._log_format(msg)}{cls.CLR_END}",
             flush=True)
@@ -88,6 +108,9 @@ class Log(ABC):
         Args:
             msg (str): log message.
         """
+        if not cls.enabled:
+            return
+        
         print(
             f"{cls.CLR_SUCCESS}{cls._log_format(msg)}{cls.CLR_END}",
             flush=True)
@@ -102,6 +125,9 @@ class Log(ABC):
         Args:
             msg (str): log message.
         """
+        if not cls.enabled:
+            return
+        
         print(
             f"{cls.CLR_WARNING}{cls._log_format(msg)}{cls.CLR_END}",
             flush=True)
@@ -116,6 +142,8 @@ class Log(ABC):
         Args:
             msg (str): log message.
         """
+        if not cls.enabled:
+            return
         
         print(
             f"{cls.CLR_ERROR}{cls._log_format(msg)}{cls.CLR_END}",
@@ -131,6 +159,9 @@ class Log(ABC):
         Args:
             msg (str): log message.
         """
+        if not cls.enabled:
+            return
+        
         if arg.args.parsed_args.debug_output:
             print(cls._log_format(msg), flush=True)
 


### PR DESCRIPTION
* Stop passive repair from disabling combat and pvp module directly, use member function instead
* Add enable switch for Log module