### PR TITLE
200 secretary ship type support in factory module

### DIFF
--- a/kcauto/combat/combat_core.py
+++ b/kcauto/combat/combat_core.py
@@ -441,8 +441,8 @@ class CombatCore(CoreBase):
                 if not next_node:
                     raise ValueError("Node select not defined.")
                 else:
-                    Log.log_msg(f"Selecting node {next_node.value}")
-                    self.map_data.nodes[next_node.value].select()
+                    Log.log_msg(f"Selecting node {next_node}")
+                    self.map_data.nodes[next_node].select()
             elif node_type == self.NODE_TYPE_NOTHING:
                 pass
             elif node_type == self.NODE_TYPE_END:

--- a/kcauto/config/factory.py
+++ b/kcauto/config/factory.py
@@ -1,4 +1,5 @@
 from config.config_base import ConfigBase
+from kca_enums.ship_types import ShipTypeEnum
 
 class ConfigFactory(ConfigBase):
     enabled = False
@@ -14,5 +15,14 @@ class ConfigFactory(ConfigBase):
                 "Specified value for factory enabled is not a boolean.")
         self.develop["recipe"]  = config['factory.develop_recipe']
         self.build["recipe"]    = config['factory.build_recipe']
-        self.develop_secretary  = config['factory.develop_secretary']
-        self.build_secretary    = config['factory.build_secretary']
+        self.develop_secretary  = self._parse_secretary(config['factory.develop_secretary'])
+        self.build_secretary    = self._parse_secretary(config['factory.build_secretary'])
+
+    @staticmethod
+    def _parse_secretary(value):
+        if isinstance(value, str):
+            try:
+                return ShipTypeEnum[value.upper()]
+            except KeyError:
+                raise ValueError(f"Unknown ship type for secretary: {value!r}")
+        return value

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -20,9 +20,6 @@ STEEL_MENU = 6
 BAUXITE_MENU = 7
 SECRETARY_TYPE_MENU = 8
 
-SECRETARY_MODE_ID = 1
-SECRETARY_MODE_TYPE = 2
-
 _EXCLUDED_TYPES = {'NA', 'EAO', 'SD', 'WILDCARD'}
 SECRETARY_TYPE_OPTIONS = ['on-hand', 'ID'] + [
     t.name for t in _ShipTypeEnum if t.name not in _EXCLUDED_TYPES
@@ -146,8 +143,6 @@ def pop_up_menu(stdscr, panel, config):
                   x_recipe + len("PRESETNAME    XAMMOX XXXX  "), 
                   x_recipe + len("PRESETNAME    XAMMOX XXXX  XBAUXITEX ")]
     
-    secretary_mode = SECRETARY_MODE_ID
-    
     while True:
         
         panel.clear()
@@ -164,7 +159,7 @@ def pop_up_menu(stdscr, panel, config):
         # --- mode selector (type cycling) ---
         sec_mode = secretary[current_tab]
         mode_in_type_menu = (current_active == SECRETARY_TYPE_MENU)
-        mode_focused = (current_active == TOP_MENU and curser[CURSER_Y] == 1 and curser[CURSER_X] == 1)
+        mode_focused = (current_active == TOP_MENU and curser[CURSER_Y] == 1 and (sec_mode != 'ID' or curser[CURSER_X] < 2))  # focused if on secretary row and either not in ID mode or not on the digit column
         if mode_in_type_menu:
             mode_label = f"<{sec_mode.ljust(8)}>"
             mode_color = curses.color_pair(LOG_GREEN)
@@ -358,13 +353,13 @@ def pop_up_menu(stdscr, panel, config):
         elif key == KEY_ENTER:
             if current_active == TOP_MENU:
                 if curser[CURSER_Y] == 1:
-                    if curser[CURSER_X] == 1:
-                        # enter type-cycling mode for the mode selector
-                        current_active = SECRETARY_TYPE_MENU
-                    elif curser[CURSER_X] == 2 and secretary[current_tab] == 'ID':
+                    if curser[CURSER_X] == 2 and secretary[current_tab] == 'ID':
                         # enter digit-edit mode for the ship-ID field
                         current_active = SECRETARY_MENU
                         curser[CURSER_X] = 6
+                    else:
+                        # enter type-cycling mode for the mode selector
+                        current_active = SECRETARY_TYPE_MENU
                 elif curser[CURSER_Y] >= 2:
                     if curser[CURSER_X] == 0:
                     

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -3,6 +3,7 @@ import curses
 import cui.util as util
 from cui.macro import *
 from util.json_data import JsonData
+from kca_enums.ship_types import ShipTypeEnum as _ShipTypeEnum
 
 from fleet.noro6 import Noro6 
 from config.macro import RECIPE_PRESET_CONSTRUCT, RECIPE_PRESET_DEVELOP, RECIPE_PRESET_CONSTRUCT_TEMPLATE, RECIPE_PRESET_DEVELOP_TEMPLATE
@@ -17,9 +18,16 @@ FUEL_MENU = 4
 AMMO_MENU = 5
 STEEL_MENU = 6
 BAUXITE_MENU = 7
+SECRETARY_TYPE_MENU = 8
 
 SECRETARY_MODE_ID = 1
 SECRETARY_MODE_TYPE = 2
+
+_EXCLUDED_TYPES = {'NA', 'EAO', 'SD', 'WILDCARD'}
+SECRETARY_TYPE_OPTIONS = ['on-hand', 'ID'] + [
+    t.name for t in _ShipTypeEnum if t.name not in _EXCLUDED_TYPES
+]
+_SEC_MODE_FIELD = 10  # " " + name.ljust(8) + "|< or >" — fixed display width
 
 MAX_QUEST_COL = 16
 
@@ -45,7 +53,8 @@ CURSER_Y = 1
 
 recipe_preset = {}
 recipe = {}
-secretary = {}
+secretary = {}    # mode per tab: 'on-hand' | 'ID' | ship-type name (e.g. 'DD')
+secretary_id = {} # digit list [7] per tab — only used when mode == 'ID'
 
 def int_to_list(n, length):
     ret = []
@@ -105,18 +114,26 @@ def pop_up_menu(stdscr, panel, config):
         for i in range(len(recipe[tab])):
             recipe[tab][i] = int_to_list(recipe[tab][i], 4)
             
-    secretary[CONSTRUCT_TAB] = int_to_list(config["factory.build_secretary"], 7)
-    secretary[DEVELOP_TAB] = int_to_list(config["factory.develop_secretary"], 7)
-    
-    if secretary[CONSTRUCT_TAB] == [0,0,0,0,0,0,0]:
-        secretary[CONSTRUCT_TAB] = 'on-hand'
-    if secretary[DEVELOP_TAB] == [0,0,0,0,0,0,0]:
-        secretary[DEVELOP_TAB] = 'on-hand'
+    def _load_secretary(value):
+        """Return (mode_str, id_digit_list) from a raw config value."""
+        if isinstance(value, str) and value not in ('on-hand',):
+            return value, [0, 0, 0, 0, 0, 0, 0]   # ship-type name
+        if not isinstance(value, int) or value == 0:
+            return 'on-hand', [0, 0, 0, 0, 0, 0, 0]
+        return 'ID', int_to_list(value, 7)
+
+    secretary[CONSTRUCT_TAB], secretary_id[CONSTRUCT_TAB] = _load_secretary(config["factory.build_secretary"])
+    secretary[DEVELOP_TAB],   secretary_id[DEVELOP_TAB]   = _load_secretary(config["factory.develop_secretary"])
         
     tab_col = [width//2//2 - len(" construct ")//2, width//2 + width//2//2 - len(" develop ")//2]
     
-    x_secretary, y_secretary = util.get_center_str_location(panel, "Secretary ship XXXX XXXXXXX")
-    secretary_col = [x_secretary, x_secretary + len("Secretary ship "), x_secretary + len("Secretary ship XXXX ")]
+    x_secretary, y_secretary = util.get_center_str_location(
+        panel, "Secretary ship " + "X" * _SEC_MODE_FIELD + "X" * 7)
+    secretary_col = [
+        x_secretary,                                        # "Secretary ship " start
+        x_secretary + len("Secretary ship "),               # mode label start  (width: _SEC_MODE_FIELD)
+        x_secretary + len("Secretary ship ") + _SEC_MODE_FIELD,  # ship-id digits start (width: 7)
+    ]
     
     x_recipe, y_recipe = util.get_center_str_location(panel, "PRESETNAME  XAMMOX XXXX  XBAUXITEX XXXX")
     recipe_col = [x_recipe, 
@@ -140,22 +157,35 @@ def pop_up_menu(stdscr, panel, config):
         
         panel.addstr(row[1] + 1, secretary_col[0], "Secretary ship ", curses.color_pair(LOG))
         
-        panel.addstr(row[1] + 1, secretary_col[1], " ID ", curses.color_pair(LOG))
-        
-        if current_active == SECRETARY_MENU:
-            for i in range(7):
-                if curser[CURSER_Y] == 1 and i == curser[CURSER_X]:
-                    panel.addstr(row[1] + 0, secretary_col[2] + i, str((secretary[current_tab][i] +9) % 10), curses.color_pair(LOG))
-                    panel.addstr(row[1] + 1, secretary_col[2] + i, str(secretary[current_tab][i]), curses.color_pair(LOG_GREEN))
-                    panel.addstr(row[1] + 2, secretary_col[2] + i, str((secretary[current_tab][i] +1) % 10), curses.color_pair(LOG))
-                else:    
-                    panel.addstr(row[1] + 1, secretary_col[2] + i, str(secretary[current_tab][i]), curses.color_pair(LOG))
+        # --- mode selector (type cycling) ---
+        sec_mode = secretary[current_tab]
+        mode_in_type_menu = (current_active == SECRETARY_TYPE_MENU)
+        mode_focused = (current_active == TOP_MENU and curser[CURSER_Y] == 1 and curser[CURSER_X] == 1)
+        if mode_in_type_menu:
+            mode_label = f"<{sec_mode.ljust(8)}>"
+            mode_color = curses.color_pair(LOG_GREEN)
+        elif mode_focused:
+            mode_label = f" {sec_mode.ljust(8)} "
+            mode_color = curses.color_pair(LOG_GREEN)
         else:
-            
-            if curser[CURSER_Y] == 1:
-                panel.addstr(row[1] + 1, secretary_col[2], str(list_to_int(secretary[current_tab])), curses.color_pair(LOG_GREEN))
+            mode_label = f" {sec_mode.ljust(8)} "
+            mode_color = curses.color_pair(LOG)
+        panel.addstr(row[1] + 1, secretary_col[1], mode_label, mode_color)
+
+        # --- ship-ID digits (only visible when mode is 'ID') ---
+        if sec_mode == 'ID':
+            if current_active == SECRETARY_MENU:
+                for i in range(7):
+                    if i == curser[CURSER_X]:
+                        panel.addstr(row[1] + 0, secretary_col[2] + i, str((secretary_id[current_tab][i] + 9) % 10), curses.color_pair(LOG))
+                        panel.addstr(row[1] + 1, secretary_col[2] + i, str(secretary_id[current_tab][i]), curses.color_pair(LOG_GREEN))
+                        panel.addstr(row[1] + 2, secretary_col[2] + i, str((secretary_id[current_tab][i] + 1) % 10), curses.color_pair(LOG))
+                    else:
+                        panel.addstr(row[1] + 1, secretary_col[2] + i, str(secretary_id[current_tab][i]), curses.color_pair(LOG))
             else:
-                panel.addstr(row[1] + 1, secretary_col[2], str(list_to_int(secretary[current_tab])), curses.color_pair(LOG))
+                id_focused = (current_active == TOP_MENU and curser[CURSER_Y] == 1 and curser[CURSER_X] == 2)
+                id_color = curses.color_pair(LOG_GREEN if id_focused else LOG)
+                panel.addstr(row[1] + 1, secretary_col[2], str(list_to_int(secretary_id[current_tab])).rjust(7), id_color)
         
         for recipe_idx, preset in enumerate(recipe_preset[current_tab]):
             
@@ -231,8 +261,11 @@ def pop_up_menu(stdscr, panel, config):
                     elif curser[CURSER_Y] < recipe_preset[current_tab].__len__() + 1:
                         curser[CURSER_Y] += 1
                     y_offset = min(y_offset, (resource_height-2) - (curser[CURSER_Y] -2 +1) )
+            elif current_active == SECRETARY_TYPE_MENU:
+                idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
+                secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx + 1) % len(SECRETARY_TYPE_OPTIONS)]
             elif current_active == SECRETARY_MENU:
-                secretary[current_tab][curser[CURSER_X]] = (secretary[current_tab][curser[CURSER_X]] + 1) %10
+                secretary_id[current_tab][curser[CURSER_X]] = (secretary_id[current_tab][curser[CURSER_X]] + 1) % 10
             elif current_active == FUEL_MENU or current_active == AMMO_MENU or current_active == STEEL_MENU or current_active == BAUXITE_MENU:
                 recipe[current_tab][RESOURCE_ORDER.index(current_active)][curser[CURSER_X]] \
                     = (recipe[current_tab][RESOURCE_ORDER.index(current_active)][curser[CURSER_X]] + 1) %10
@@ -243,8 +276,11 @@ def pop_up_menu(stdscr, panel, config):
                     curser[CURSER_Y] -= 1
                     if curser[CURSER_Y] >1 and curser[CURSER_X] == 0:
                         y_offset = max(y_offset, -(curser[CURSER_Y] -2))
+            elif current_active == SECRETARY_TYPE_MENU:
+                idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
+                secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx - 1) % len(SECRETARY_TYPE_OPTIONS)]
             elif current_active == SECRETARY_MENU:
-                secretary[current_tab][curser[CURSER_X]] = (secretary[current_tab][curser[CURSER_X]] + 9) %10
+                secretary_id[current_tab][curser[CURSER_X]] = (secretary_id[current_tab][curser[CURSER_X]] + 9) % 10
             elif current_active == FUEL_MENU or current_active == AMMO_MENU or current_active == STEEL_MENU or current_active == BAUXITE_MENU:
                 recipe[current_tab][RESOURCE_ORDER.index(current_active)][curser[CURSER_X]] \
                     = (recipe[current_tab][RESOURCE_ORDER.index(current_active)][curser[CURSER_X]] + 9) %10
@@ -260,8 +296,13 @@ def pop_up_menu(stdscr, panel, config):
                     if curser[CURSER_X] < 2:
                         if curser[CURSER_X] == 0:
                             curser[CURSER_Y] = 2
-                        curser[CURSER_X] += 1
-                        
+                            curser[CURSER_X] += 1
+                        elif curser[CURSER_Y] != 1 or secretary[current_tab] == 'ID':
+                            # on secretary row: only reach digit-column when mode is ID
+                            curser[CURSER_X] += 1
+            elif current_active == SECRETARY_TYPE_MENU:
+                idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
+                secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx + 1) % len(SECRETARY_TYPE_OPTIONS)]
             elif current_active == SECRETARY_MENU:
                 if curser[CURSER_X] < 6:
                     curser[CURSER_X] += 1
@@ -276,12 +317,13 @@ def pop_up_menu(stdscr, panel, config):
                         current_tab = TAB_ORDER[TAB_ORDER.index(current_tab)-1]
                         curser[CURSER_X] = 1
                 else:
-                        
-                    
                     if curser[CURSER_X] != 0:
                         if curser[CURSER_X] == 1:
                             curser[CURSER_Y] = 2 - y_offset
                         curser[CURSER_X] -= 1
+            elif current_active == SECRETARY_TYPE_MENU:
+                idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
+                secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx - 1) % len(SECRETARY_TYPE_OPTIONS)]
             elif current_active == SECRETARY_MENU:
                 if curser[CURSER_X] > 0:
                     curser[CURSER_X] -= 1
@@ -292,10 +334,13 @@ def pop_up_menu(stdscr, panel, config):
         elif key == KEY_ENTER:
             if current_active == TOP_MENU:
                 if curser[CURSER_Y] == 1:
-                    current_active = SECRETARY_MENU
-                    curser[CURSER_X] = 6
-                    if secretary[current_tab] == 'on-hand':
-                        secretary[current_tab] = [0,0,0,0,0,0,0]
+                    if curser[CURSER_X] == 1:
+                        # enter type-cycling mode for the mode selector
+                        current_active = SECRETARY_TYPE_MENU
+                    elif curser[CURSER_X] == 2 and secretary[current_tab] == 'ID':
+                        # enter digit-edit mode for the ship-ID field
+                        current_active = SECRETARY_MENU
+                        curser[CURSER_X] = 6
                 elif curser[CURSER_Y] >= 2:
                     if curser[CURSER_X] == 0:
                     
@@ -311,10 +356,7 @@ def pop_up_menu(stdscr, panel, config):
                             secretary_name = "factory.develop_secretary"
                         
                         secretary_int = list(recipe_preset[current_tab].items())[preset_idx][1][secretary_name]
-                        if secretary_int == 0:
-                            secretary[current_tab] = "on-hand"
-                        else:
-                            secretary[current_tab] = int_to_list(secretary_int, 7)
+                        secretary[current_tab], secretary_id[current_tab] = _load_secretary(secretary_int)
                             
                         recipe[current_tab] = [int_to_list(n,4) for n in list(recipe_preset[current_tab].items())[preset_idx][1][recipe_name]]
                     
@@ -323,12 +365,14 @@ def pop_up_menu(stdscr, panel, config):
                         curser[CURSER_Y] = None
                         curser[CURSER_X] = 3
                     
-            elif current_active == SECRETARY_MENU:
+            elif current_active == SECRETARY_TYPE_MENU:
                 current_active = TOP_MENU
                 curser[CURSER_X] = 1
                 curser[CURSER_Y] = 1
-                if secretary[current_tab] == [0,0,0,0,0,0,0]:
-                    secretary[current_tab] = 'on-hand'
+            elif current_active == SECRETARY_MENU:
+                current_active = TOP_MENU
+                curser[CURSER_X] = 2  # return focus to digit column
+                curser[CURSER_Y] = 1
             elif current_active == FUEL_MENU or current_active == AMMO_MENU or current_active == STEEL_MENU or current_active == BAUXITE_MENU:
                 curser[CURSER_X] = RESOURCE_ORDER.index(current_active)//2 +1
                 curser[CURSER_Y] = RESOURCE_ORDER.index(current_active)%2 +2
@@ -347,15 +391,17 @@ def set_config(config):
     
     for resource in recipe[CONSTRUCT_TAB]:
         config["factory.build_recipe"].append(list_to_int(resource))
-    if secretary[CONSTRUCT_TAB] == 'on-hand':
-        config["factory.build_secretary"] = 0
-    else:   
-        config["factory.build_secretary"] = list_to_int(secretary[CONSTRUCT_TAB])
-        
+    def _save_secretary(tab):
+        mode = secretary[tab]
+        if mode == 'on-hand':
+            return 0
+        if mode == 'ID':
+            return list_to_int(secretary_id[tab])
+        return mode  # ship-type name string
+
+    config["factory.build_secretary"] = _save_secretary(CONSTRUCT_TAB)
+
     for resource in recipe[DEVELOP_TAB]:
         config["factory.develop_recipe"].append(list_to_int(resource))
-    if secretary[DEVELOP_TAB] == 'on-hand':
-        config["factory.develop_secretary"] = 0 
-    else:
-        config["factory.develop_secretary"] = list_to_int(secretary[DEVELOP_TAB])
+    config["factory.develop_secretary"] = _save_secretary(DEVELOP_TAB)
     return

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -26,8 +26,6 @@ SECRETARY_TYPE_OPTIONS = ['on-hand', 'ID'] + [
 ]
 _SEC_MODE_FIELD = 10  # " " + name.ljust(8) + "|< or >" — fixed display width
 
-MAX_QUEST_COL = 16
-
 TAB_ORDER = [CONSTRUCT_TAB, DEVELOP_TAB]
 RESOURCE_ORDER = [FUEL_MENU, AMMO_MENU, STEEL_MENU, BAUXITE_MENU]
 RESOURCE_PANEL_LAYOUT = [
@@ -47,6 +45,18 @@ COL_NEEDED_WIDTH = 5
 
 CURSER_X = 0
 CURSER_Y = 1
+
+# Index as python list, [include:exclude]
+TOP_TAP_ROW = 0
+SECRETARY_ROW = TOP_TAP_ROW + 2
+RESOURCE_ROW_START = SECRETARY_ROW + 2
+RESOURCE_ROW_END = RESOURCE_ROW_START + 3
+
+COMMENT_ROW_START = RESOURCE_ROW_END + 1
+COMMENT_ROW_END = COMMENT_ROW_START + 2
+
+RECIPE_ROW_START = RESOURCE_ROW_START
+
 
 recipe_preset = {}
 recipe = {}
@@ -91,16 +101,18 @@ def pop_up_menu(stdscr, panel, config):
             JsonData.dump_json(JsonData.load_json(RECIPE_PRESET_DEVELOP_TEMPLATE), RECIPE_PRESET_DEVELOP)
             recipe_preset[DEVELOP_TAB] = JsonData.load_json(RECIPE_PRESET_DEVELOP)
     
-    current_tab = CONSTRUCT_TAB 
-    current_active = TOP_MENU 
+    current_tab = CONSTRUCT_TAB
+    current_active = TOP_MENU
     curser = [1, 0]
     
     height, width = panel.getmaxyx()
     
+    RECIPE_ROW_END =  height - 2
+    
+    
     tab_height = 1
     secretary_height = 2
-    resource_height = min((height - (tab_height + secretary_height)), 15)
-    y_offset = 0
+    recipe_y_offset = 0 #the id of the first recipe currently displayed
     
     row = [0, tab_height, tab_height + secretary_height]
     
@@ -188,16 +200,16 @@ def pop_up_menu(stdscr, panel, config):
         
         for recipe_idx, preset in enumerate(recipe_preset[current_tab]):
             
-            if recipe_idx < (y_offset * -1):
+            if recipe_idx < (recipe_y_offset * -1):
                 continue
             
-            if recipe_idx > resource_height - y_offset - 3:
+            if recipe_idx > RECIPE_ROW_END - RECIPE_ROW_START - recipe_y_offset:
                 break
             
             if curser[CURSER_Y] == recipe_idx + 2 and curser[CURSER_X] == 0:
-                panel.addstr(row[2] + 1 + recipe_idx + y_offset, recipe_col[0], preset, curses.color_pair(LOG_GREEN))
+                panel.addstr(row[2] + 1 + recipe_idx + recipe_y_offset, recipe_col[0], preset, curses.color_pair(LOG_GREEN))
             else:
-                panel.addstr(row[2] + 1 + recipe_idx + y_offset, recipe_col[0], preset, curses.color_pair(LOG))
+                panel.addstr(row[2] + 1 + recipe_idx + recipe_y_offset, recipe_col[0], preset, curses.color_pair(LOG))
         
         for resource_idx, resource in enumerate(RESOURCE_ORDER):
             
@@ -271,15 +283,20 @@ def pop_up_menu(stdscr, panel, config):
         
         if key == curses.KEY_DOWN or key == ord('j'):
             if current_active == TOP_MENU:
-                if curser[CURSER_X] != 0:
-                    if curser[CURSER_Y] < 3:
-                        curser[CURSER_Y] += 1
+                if curser[CURSER_Y] == 0:
+                    curser[CURSER_Y] = 1  
+                    curser[CURSER_X] = 0
+                elif curser[CURSER_Y] == 1:
+                    curser[CURSER_Y] = 2
+                    curser[CURSER_X] = 1
                 else:
-                    if curser[CURSER_Y] < 1:
-                        curser[CURSER_Y] += 1
-                    elif curser[CURSER_Y] < recipe_preset[current_tab].__len__() + 1:
-                        curser[CURSER_Y] += 1
-                    y_offset = min(y_offset, (resource_height-2) - (curser[CURSER_Y] -2 +1) )
+                    if curser[CURSER_X] == 0:
+                        if curser[CURSER_Y] < recipe_preset[current_tab].__len__() + 1:
+                            curser[CURSER_Y] += 1
+                        recipe_y_offset = max(recipe_y_offset,  (curser[CURSER_Y] -2) +1 - (RECIPE_ROW_END - RECIPE_ROW_START))
+                    else:
+                        if curser[CURSER_Y] < 3:
+                            curser[CURSER_Y] += 1
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
                 secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx + 1) % len(SECRETARY_TYPE_OPTIONS)]
@@ -291,10 +308,16 @@ def pop_up_menu(stdscr, panel, config):
                 
         elif key == curses.KEY_UP or key == ord('k'):
             if current_active == TOP_MENU:
-                if curser[CURSER_Y] > 0:
+                if curser[CURSER_Y] == 1:
+                    curser[CURSER_Y] = 0
+                    curser[CURSER_X] = 0
+                elif curser[CURSER_Y] == 2:
+                    curser[CURSER_Y] = 1
+                    curser[CURSER_X] = 0
+                else:
                     curser[CURSER_Y] -= 1
-                    if curser[CURSER_Y] >1 and curser[CURSER_X] == 0:
-                        y_offset = max(y_offset, -(curser[CURSER_Y] -2))
+                    if curser[CURSER_X] == 0:
+                        recipe_y_offset = max(recipe_y_offset, -(curser[CURSER_Y] -2))
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
                 secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx - 1) % len(SECRETARY_TYPE_OPTIONS)]
@@ -311,14 +334,17 @@ def pop_up_menu(stdscr, panel, config):
                     if current_tab != TAB_ORDER[-1]:
                         current_tab = TAB_ORDER[TAB_ORDER.index(current_tab)+1]
                         curser[CURSER_X] = 1
-                else:
-                    if curser[CURSER_X] < 2:
-                        if curser[CURSER_X] == 0:
-                            curser[CURSER_Y] = 2
-                            curser[CURSER_X] += 1
-                        elif curser[CURSER_Y] != 1 or secretary[current_tab] == 'ID':
-                            # on secretary row: only reach digit-column when mode is ID
-                            curser[CURSER_X] += 1
+                elif curser[CURSER_Y] == 1:
+                    if curser[CURSER_X] != 2:
+                        # on secretary row: only reach digit-column when mode is ID
+                        if secretary[current_tab] == 'ID':
+                            curser[CURSER_X] = 2
+                else:    
+                    if curser[CURSER_X] == 0:
+                        curser[CURSER_Y] = 2
+                        curser[CURSER_X] += 1
+                    else:
+                        curser[CURSER_X] += 1
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
                 secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx + 1) % len(SECRETARY_TYPE_OPTIONS)]
@@ -335,10 +361,13 @@ def pop_up_menu(stdscr, panel, config):
                     if current_tab != TAB_ORDER[0]:
                         current_tab = TAB_ORDER[TAB_ORDER.index(current_tab)-1]
                         curser[CURSER_X] = 1
+                elif curser[CURSER_Y] == 1:
+                    if curser[CURSER_X] != 0:
+                        curser[CURSER_X] -= 1
                 else:
                     if curser[CURSER_X] != 0:
                         if curser[CURSER_X] == 1:
-                            curser[CURSER_Y] = 2 - y_offset
+                            curser[CURSER_Y] = 2 - recipe_y_offset
                         curser[CURSER_X] -= 1
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -55,6 +55,7 @@ recipe_preset = {}
 recipe = {}
 secretary = {}    # mode per tab: 'on-hand' | 'ID' | ship-type name (e.g. 'DD')
 secretary_id = {} # digit list [7] per tab — only used when mode == 'ID'
+comment = {}      # comment string for the currently-loaded preset per tab
 
 def int_to_list(n, length):
     ret = []
@@ -124,6 +125,9 @@ def pop_up_menu(stdscr, panel, config):
 
     secretary[CONSTRUCT_TAB], secretary_id[CONSTRUCT_TAB] = _load_secretary(config["factory.build_secretary"])
     secretary[DEVELOP_TAB],   secretary_id[DEVELOP_TAB]   = _load_secretary(config["factory.develop_secretary"])
+
+    comment[CONSTRUCT_TAB] = ""
+    comment[DEVELOP_TAB]   = ""
         
     tab_col = [width//2//2 - len(" construct ")//2, width//2 + width//2//2 - len(" develop ")//2]
     
@@ -244,10 +248,30 @@ def pop_up_menu(stdscr, panel, config):
                 else:
                     panel.addstr(row[2] + row_local_offset + 1, recipe_col[col_offset +1], str(list_to_int(recipe[current_tab][resource_idx])).rjust(4, " "), curses.color_pair(LOG))
                
-        
-        panel.refresh()
+        # --- comment area (right column only, below resource panel) ---
+        # resource panel occupies row[2]+0 .. row[2]+4; comment goes just below
+        comment_row_0 = row[2] + 5
+        comment_row_1 = row[2] + 6
+        comment_x     = recipe_col[1]           # same left edge as resource panel
+        comment_w     = width - comment_x - 1   # up to the right border
 
-        # Wait for next input
+        display_comment = comment[current_tab]
+        if current_active == TOP_MENU and curser[CURSER_X] == 0 and curser[CURSER_Y] >= 2:
+            hover_idx = curser[CURSER_Y] - 2
+            presets_list = list(recipe_preset[current_tab].items())
+            if 0 <= hover_idx < len(presets_list):
+                display_comment = presets_list[hover_idx][1].get("comment", "")
+
+        if comment_row_0 < height - 1:
+            panel.addstr(comment_row_0, comment_x,
+                         display_comment[:comment_w].ljust(comment_w),
+                         curses.color_pair(LOG))
+        if comment_row_1 < height - 1:
+            panel.addstr(comment_row_1, comment_x,
+                         display_comment[comment_w:comment_w * 2].ljust(comment_w),
+                         curses.color_pair(LOG))
+
+        panel.refresh()
         key = stdscr.getch()
         
         if key == curses.KEY_DOWN or key == ord('j'):
@@ -357,6 +381,7 @@ def pop_up_menu(stdscr, panel, config):
                         
                         secretary_int = list(recipe_preset[current_tab].items())[preset_idx][1][secretary_name]
                         secretary[current_tab], secretary_id[current_tab] = _load_secretary(secretary_int)
+                        comment[current_tab] = list(recipe_preset[current_tab].items())[preset_idx][1].get("comment", "")
                             
                         recipe[current_tab] = [int_to_list(n,4) for n in list(recipe_preset[current_tab].items())[preset_idx][1][recipe_name]]
                     

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -201,7 +201,7 @@ def pop_up_menu(stdscr, panel, config):
                 continue
 
             row = recipe_idx - recipe_y_offset
-            if row >= RECIPE_ROW_END - RECIPE_ROW_START:
+            if row > RECIPE_ROW_END - RECIPE_ROW_START:
                 break
 
             if curser[CURSER_Y] == row + 2 and curser[CURSER_X] == 0:
@@ -294,7 +294,7 @@ def pop_up_menu(stdscr, panel, config):
                         recipe_idx_current = curser[CURSER_Y] - 2 + recipe_y_offset
                         if recipe_idx_current + 1 < len(recipe_preset[current_tab]):
                             visible_row = recipe_idx_current - recipe_y_offset
-                            if visible_row < RECIPE_ROW_END - RECIPE_ROW_START - 1:
+                            if visible_row < RECIPE_ROW_END - RECIPE_ROW_START :
                                 curser[CURSER_Y] += 1
                             else:
                                 recipe_y_offset += 1
@@ -316,9 +316,24 @@ def pop_up_menu(stdscr, panel, config):
                     curser[CURSER_Y] = 0
                     curser[CURSER_X] = 0
                 elif curser[CURSER_Y] == 2:
-                    curser[CURSER_Y] = 1
-                    curser[CURSER_X] = 0
+                    
+                    if curser[CURSER_X] == 0:
+                        
+                        recipe_idx_current = curser[CURSER_Y] - 2 + recipe_y_offset
+                        if recipe_idx_current > 0:
+                            visible_row = recipe_idx_current - recipe_y_offset
+                            if visible_row >= 0:
+                                recipe_y_offset -= 1
+                        else:
+                            curser[CURSER_Y] -= 1
+                            curser[CURSER_X] = 0
+                                    
+                    else:
+                        curser[CURSER_Y] -= 1
+                        curser[CURSER_X] = 0
+                    
                 elif curser[CURSER_Y] > 2:
+                    #when in preset list, move up will scroll up if cursor is on the first visible preset
                     curser[CURSER_Y] -= 1
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -261,7 +261,9 @@ def pop_up_menu(stdscr, panel, config):
 
         display_comment = comment[current_tab]
         if current_active == TOP_MENU and curser[CURSER_X] == 0 and curser[CURSER_Y] >= 2:
-            hover_idx = curser[CURSER_Y] - 2
+            # Convert cursor Y position (visible row) to actual preset index using scroll offset.
+            hover_visible_idx = curser[CURSER_Y] - 2
+            hover_idx = hover_visible_idx + recipe_y_offset
             presets_list = list(recipe_preset[current_tab].items())
             if 0 <= hover_idx < len(presets_list):
                 display_comment = presets_list[hover_idx][1].get("comment", "")

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -47,8 +47,8 @@ CURSER_X = 0
 CURSER_Y = 1
 
 # Index as python list, [include:exclude]
-TOP_TAP_ROW = 0
-SECRETARY_ROW = TOP_TAP_ROW + 2
+TOP_TAB_ROW = 0
+SECRETARY_ROW = TOP_TAB_ROW + 2
 RESOURCE_ROW_START = SECRETARY_ROW + 2
 RESOURCE_ROW_END = RESOURCE_ROW_START + 3
 
@@ -110,11 +110,8 @@ def pop_up_menu(stdscr, panel, config):
     RECIPE_ROW_END =  height - 2
     
     
-    tab_height = 1
-    secretary_height = 2
     recipe_y_offset = 0 #the id of the first recipe currently displayed
     
-    row = [0, tab_height, tab_height + secretary_height]
     
     #read current quest status from config
     recipe[CONSTRUCT_TAB] = config["factory.build_recipe"]
@@ -159,14 +156,14 @@ def pop_up_menu(stdscr, panel, config):
         
         panel.clear()
         panel.border()
-        panel.addstr(row[0], tab_col[0], 
+        panel.addstr(TOP_TAB_ROW, tab_col[0], 
                     ("<" if curser[CURSER_Y] == 0 and current_tab == CONSTRUCT_TAB else " ")+"Construct"+(">" if curser[CURSER_Y] == 0 and current_tab == CONSTRUCT_TAB else " "),
                     curses.color_pair(CONSTRUCT + (COLOR_REVERT * (int(current_tab == CONSTRUCT_TAB)))))
-        panel.addstr(row[0], tab_col[1], 
+        panel.addstr(TOP_TAB_ROW, tab_col[1], 
                     ("<" if curser[CURSER_Y] == 0 and current_tab == DEVELOP_TAB else " ")+"Develop"+(">" if curser[CURSER_Y] == 0 and current_tab == DEVELOP_TAB else " "),
                     curses.color_pair(DEVELOP + (COLOR_REVERT * (int(current_tab == DEVELOP_TAB)))))
         
-        panel.addstr(row[1] + 1, secretary_col[0], "Secretary ship ", curses.color_pair(LOG))
+        panel.addstr(SECRETARY_ROW, secretary_col[0], "Secretary ship ", curses.color_pair(LOG))
         
         # --- mode selector (type cycling) ---
         sec_mode = secretary[current_tab]
@@ -181,22 +178,22 @@ def pop_up_menu(stdscr, panel, config):
         else:
             mode_label = f" {sec_mode.ljust(8)} "
             mode_color = curses.color_pair(LOG)
-        panel.addstr(row[1] + 1, secretary_col[1], mode_label, mode_color)
+        panel.addstr(SECRETARY_ROW, secretary_col[1], mode_label, mode_color)
 
         # --- ship-ID digits (only visible when mode is 'ID') ---
         if sec_mode == 'ID':
             if current_active == SECRETARY_MENU:
                 for i in range(7):
                     if i == curser[CURSER_X]:
-                        panel.addstr(row[1] + 0, secretary_col[2] + i, str((secretary_id[current_tab][i] + 9) % 10), curses.color_pair(LOG))
-                        panel.addstr(row[1] + 1, secretary_col[2] + i, str(secretary_id[current_tab][i]), curses.color_pair(LOG_GREEN))
-                        panel.addstr(row[1] + 2, secretary_col[2] + i, str((secretary_id[current_tab][i] + 1) % 10), curses.color_pair(LOG))
+                        panel.addstr(SECRETARY_ROW - 1, secretary_col[2] + i, str((secretary_id[current_tab][i] + 9) % 10), curses.color_pair(LOG))
+                        panel.addstr(SECRETARY_ROW + 0, secretary_col[2] + i, str(secretary_id[current_tab][i]), curses.color_pair(LOG_GREEN))
+                        panel.addstr(SECRETARY_ROW + 1, secretary_col[2] + i, str((secretary_id[current_tab][i] + 1) % 10), curses.color_pair(LOG))
                     else:
-                        panel.addstr(row[1] + 1, secretary_col[2] + i, str(secretary_id[current_tab][i]), curses.color_pair(LOG))
+                        panel.addstr(SECRETARY_ROW , secretary_col[2] + i, str(secretary_id[current_tab][i]), curses.color_pair(LOG))
             else:
                 id_focused = (current_active == TOP_MENU and curser[CURSER_Y] == 1 and curser[CURSER_X] == 2)
                 id_color = curses.color_pair(LOG_GREEN if id_focused else LOG)
-                panel.addstr(row[1] + 1, secretary_col[2], str(list_to_int(secretary_id[current_tab])).rjust(7), id_color)
+                panel.addstr(SECRETARY_ROW, secretary_col[2], str(list_to_int(secretary_id[current_tab])).rjust(7), id_color)
         
         for recipe_idx, preset in enumerate(recipe_preset[current_tab]):
             
@@ -207,9 +204,9 @@ def pop_up_menu(stdscr, panel, config):
                 break
             
             if curser[CURSER_Y] == recipe_idx + 2 and curser[CURSER_X] == 0:
-                panel.addstr(row[2] + 1 + recipe_idx + recipe_y_offset, recipe_col[0], preset, curses.color_pair(LOG_GREEN))
+                panel.addstr(RECIPE_ROW_START + (recipe_idx + recipe_y_offset), recipe_col[0], preset, curses.color_pair(LOG_GREEN))
             else:
-                panel.addstr(row[2] + 1 + recipe_idx + recipe_y_offset, recipe_col[0], preset, curses.color_pair(LOG))
+                panel.addstr(RECIPE_ROW_START + (recipe_idx + recipe_y_offset), recipe_col[0], preset, curses.color_pair(LOG))
         
         for resource_idx, resource in enumerate(RESOURCE_ORDER):
             
@@ -239,26 +236,26 @@ def pop_up_menu(stdscr, panel, config):
                 color = REPAIR 
                 if curser[CURSER_Y] == 3 and curser[CURSER_X] == 2:
                     focus = BAUXITE_MENU
-            panel.addstr(row[2] + row_local_offset + 1, recipe_col[col_offset], " "+RESOURCE_DISPLAY_NAME[resource]+" ", curses.color_pair(color))
+            panel.addstr(RESOURCE_ROW_START + row_local_offset, recipe_col[col_offset], " "+RESOURCE_DISPLAY_NAME[resource]+" ", curses.color_pair(color))
         
             if current_active == resource:    
                 for i in range(4):
                     if i == curser[CURSER_X]:
-                        panel.addstr(row[2] + row_local_offset + 0, recipe_col[col_offset +1] + i, str((recipe[current_tab][resource_idx][i] +9) % 10), curses.color_pair(LOG))
-                        panel.addstr(row[2] + row_local_offset + 1, recipe_col[col_offset +1] + i, str(recipe[current_tab][resource_idx][i]), curses.color_pair(LOG_GREEN))
-                        panel.addstr(row[2] + row_local_offset + 2, recipe_col[col_offset +1] + i, str((recipe[current_tab][resource_idx][i] +1) % 10), curses.color_pair(LOG))
+                        panel.addstr(RESOURCE_ROW_START + row_local_offset - 1, recipe_col[col_offset +1] + i, str((recipe[current_tab][resource_idx][i] +9) % 10), curses.color_pair(LOG))
+                        panel.addstr(RESOURCE_ROW_START + row_local_offset + 0, recipe_col[col_offset +1] + i, str(recipe[current_tab][resource_idx][i]), curses.color_pair(LOG_GREEN))
+                        panel.addstr(RESOURCE_ROW_START + row_local_offset + 1, recipe_col[col_offset +1] + i, str((recipe[current_tab][resource_idx][i] +1) % 10), curses.color_pair(LOG))
                     else:    
-                        panel.addstr(row[2] + row_local_offset + 1, recipe_col[col_offset +1] + i, str(recipe[current_tab][resource_idx][i]), curses.color_pair(LOG))
+                        panel.addstr(RESOURCE_ROW_START + row_local_offset + 0, recipe_col[col_offset +1] + i, str(recipe[current_tab][resource_idx][i]), curses.color_pair(LOG))
             else:
                 if focus == resource:
-                    panel.addstr(row[2] + row_local_offset + 1, recipe_col[col_offset +1], str(list_to_int(recipe[current_tab][resource_idx])).rjust(4, " "), curses.color_pair(LOG_GREEN))
+                    panel.addstr(RESOURCE_ROW_START + row_local_offset, recipe_col[col_offset +1], str(list_to_int(recipe[current_tab][resource_idx])).rjust(4, " "), curses.color_pair(LOG_GREEN))
                 else:
-                    panel.addstr(row[2] + row_local_offset + 1, recipe_col[col_offset +1], str(list_to_int(recipe[current_tab][resource_idx])).rjust(4, " "), curses.color_pair(LOG))
+                    panel.addstr(RESOURCE_ROW_START + row_local_offset, recipe_col[col_offset +1], str(list_to_int(recipe[current_tab][resource_idx])).rjust(4, " "), curses.color_pair(LOG))
                
         # --- comment area (right column only, below resource panel) ---
         # resource panel occupies row[2]+0 .. row[2]+4; comment goes just below
-        comment_row_0 = row[2] + 5
-        comment_row_1 = row[2] + 6
+        comment_row_0 = COMMENT_ROW_START
+        comment_row_1 = COMMENT_ROW_END - 1
         comment_x     = recipe_col[1]           # same left edge as resource panel
         comment_w     = width - comment_x - 1   # up to the right border
 
@@ -289,7 +286,7 @@ def pop_up_menu(stdscr, panel, config):
                 elif curser[CURSER_Y] == 1:
                     curser[CURSER_Y] = 2
                     curser[CURSER_X] = 1
-                else:
+                elif curser[CURSER_Y] > 1:
                     if curser[CURSER_X] == 0:
                         if curser[CURSER_Y] < recipe_preset[current_tab].__len__() + 1:
                             curser[CURSER_Y] += 1
@@ -314,7 +311,7 @@ def pop_up_menu(stdscr, panel, config):
                 elif curser[CURSER_Y] == 2:
                     curser[CURSER_Y] = 1
                     curser[CURSER_X] = 0
-                else:
+                elif curser[CURSER_Y] > 2:
                     curser[CURSER_Y] -= 1
                     if curser[CURSER_X] == 0:
                         recipe_y_offset = max(recipe_y_offset, -(curser[CURSER_Y] -2))
@@ -343,7 +340,7 @@ def pop_up_menu(stdscr, panel, config):
                     if curser[CURSER_X] == 0:
                         curser[CURSER_Y] = 2
                         curser[CURSER_X] += 1
-                    else:
+                    elif curser[CURSER_X] < 2:
                         curser[CURSER_X] += 1
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
@@ -364,7 +361,7 @@ def pop_up_menu(stdscr, panel, config):
                 elif curser[CURSER_Y] == 1:
                     if curser[CURSER_X] != 0:
                         curser[CURSER_X] -= 1
-                else:
+                elif curser[CURSER_Y] > 1:
                     if curser[CURSER_X] != 0:
                         if curser[CURSER_X] == 1:
                             curser[CURSER_Y] = 2 - recipe_y_offset

--- a/kcauto/cui/factory.py
+++ b/kcauto/cui/factory.py
@@ -196,17 +196,18 @@ def pop_up_menu(stdscr, panel, config):
                 panel.addstr(SECRETARY_ROW, secretary_col[2], str(list_to_int(secretary_id[current_tab])).rjust(7), id_color)
         
         for recipe_idx, preset in enumerate(recipe_preset[current_tab]):
-            
-            if recipe_idx < (recipe_y_offset * -1):
+
+            if recipe_idx < recipe_y_offset:
                 continue
-            
-            if recipe_idx > RECIPE_ROW_END - RECIPE_ROW_START - recipe_y_offset:
+
+            row = recipe_idx - recipe_y_offset
+            if row >= RECIPE_ROW_END - RECIPE_ROW_START:
                 break
-            
-            if curser[CURSER_Y] == recipe_idx + 2 and curser[CURSER_X] == 0:
-                panel.addstr(RECIPE_ROW_START + (recipe_idx + recipe_y_offset), recipe_col[0], preset, curses.color_pair(LOG_GREEN))
+
+            if curser[CURSER_Y] == row + 2 and curser[CURSER_X] == 0:
+                panel.addstr(RECIPE_ROW_START + row, recipe_col[0], preset, curses.color_pair(LOG_GREEN))
             else:
-                panel.addstr(RECIPE_ROW_START + (recipe_idx + recipe_y_offset), recipe_col[0], preset, curses.color_pair(LOG))
+                panel.addstr(RECIPE_ROW_START + row, recipe_col[0], preset, curses.color_pair(LOG))
         
         for resource_idx, resource in enumerate(RESOURCE_ORDER):
             
@@ -290,9 +291,13 @@ def pop_up_menu(stdscr, panel, config):
                     curser[CURSER_X] = 1
                 elif curser[CURSER_Y] > 1:
                     if curser[CURSER_X] == 0:
-                        if curser[CURSER_Y] < recipe_preset[current_tab].__len__() + 1:
-                            curser[CURSER_Y] += 1
-                        recipe_y_offset = max(recipe_y_offset,  (curser[CURSER_Y] -2) +1 - (RECIPE_ROW_END - RECIPE_ROW_START))
+                        recipe_idx_current = curser[CURSER_Y] - 2 + recipe_y_offset
+                        if recipe_idx_current + 1 < len(recipe_preset[current_tab]):
+                            visible_row = recipe_idx_current - recipe_y_offset
+                            if visible_row < RECIPE_ROW_END - RECIPE_ROW_START - 1:
+                                curser[CURSER_Y] += 1
+                            else:
+                                recipe_y_offset += 1
                     else:
                         if curser[CURSER_Y] < 3:
                             curser[CURSER_Y] += 1
@@ -315,8 +320,6 @@ def pop_up_menu(stdscr, panel, config):
                     curser[CURSER_X] = 0
                 elif curser[CURSER_Y] > 2:
                     curser[CURSER_Y] -= 1
-                    if curser[CURSER_X] == 0:
-                        recipe_y_offset = max(recipe_y_offset, -(curser[CURSER_Y] -2))
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
                 secretary[current_tab] = SECRETARY_TYPE_OPTIONS[(idx - 1) % len(SECRETARY_TYPE_OPTIONS)]
@@ -366,7 +369,7 @@ def pop_up_menu(stdscr, panel, config):
                 elif curser[CURSER_Y] > 1:
                     if curser[CURSER_X] != 0:
                         if curser[CURSER_X] == 1:
-                            curser[CURSER_Y] = 2 - recipe_y_offset
+                            curser[CURSER_Y] = 2
                         curser[CURSER_X] -= 1
             elif current_active == SECRETARY_TYPE_MENU:
                 idx = SECRETARY_TYPE_OPTIONS.index(secretary[current_tab])
@@ -391,7 +394,7 @@ def pop_up_menu(stdscr, panel, config):
                 elif curser[CURSER_Y] >= 2:
                     if curser[CURSER_X] == 0:
                     
-                        preset_idx = curser[CURSER_Y] -2
+                        preset_idx = curser[CURSER_Y] - 2 + recipe_y_offset
                         
                         recipe_name = ""
                         secretary_name = 0

--- a/kcauto/expedition/expedition_core.py
+++ b/kcauto/expedition/expedition_core.py
@@ -21,7 +21,7 @@ class ExpeditionCore(CoreBase):
     MONTHLY_EXPEDITION = [ExpeditionEnum.E1_A4, ExpeditionEnum.E1_A5, ExpeditionEnum.E1_A6, 
                           ExpeditionEnum.E2_B2, ExpeditionEnum.E2_B3, ExpeditionEnum.E2_B4, ExpeditionEnum.E2_B5, ExpeditionEnum.E2_B6,
                           ExpeditionEnum.E7_42, ExpeditionEnum.E7_43, ExpeditionEnum.E7_44, ExpeditionEnum.E7_46,
-                          ExpeditionEnum.E3_D2, ExpeditionEnum.E3_D3, 
+                          ExpeditionEnum.E5_D2, ExpeditionEnum.E5_D3, 
                           ExpeditionEnum.E5_E1, ExpeditionEnum.E5_E2]
     EXP_ENUM = "exp_enum"
     SCORE = "score"

--- a/kcauto/fleet/fleet.py
+++ b/kcauto/fleet/fleet.py
@@ -306,14 +306,6 @@ class Fleet(object):
         self.ships.append(ship)
         return
             
-    def remove_ship(self, ship):
-        for i, ship in enumerate(self.ships):
-            if ship.production_id == ship.production_id:
-                del self.ships[i]
-                Log.log_debug_1(f"Removed ship {ship.name} from fleet {self.fleet_id}.")
-                return
-        Log.log_debug_1(f"Ship {ship.name} not found in fleet {self.fleet_id}.")
-    
     def get_ship_by_production_id(self, production_id):
         for ship in self.ships:
             if ship.production_id == production_id:

--- a/kcauto/fleet_switcher/fleet_switcher_core.py
+++ b/kcauto/fleet_switcher/fleet_switcher_core.py
@@ -533,10 +533,10 @@ class FleetSwitcherCore(object):
         for i in range(fleet.size):
             
             if fleet.ships[i].equipment_ids == flt.fleets.fleets[flt.fleets.ACTIVE_FLEET_KEY][fleet_id].ships[i].equipment_ids:
-                Log.log_msg(f"equipment for ship {fleet.ships[i].name_jp} is already loaded")
+                Log.log_msg(f"equipment for {fleet.ships[i].name_jp} is already loaded")
                 continue
             else:
-                Log.log_msg(f"Loading equipment for ship {fleet.ships[i].name_jp}...")                
+                Log.log_msg(f"Loading equipment for {fleet.ships[i].name_jp}...")                
             
             click_ship_in_equipment_page(i)
 

--- a/kcauto/fleet_switcher/fleet_switcher_core.py
+++ b/kcauto/fleet_switcher/fleet_switcher_core.py
@@ -152,30 +152,34 @@ class FleetSwitcherCore(object):
                     ship = shp.ships.get_highest_level_ship_by_type(develop_sec)
                     if ship is None:
                         return False
-                    develop_sec_id = ship.production_id
                     Log.log_msg(
                         f"Switching to highest level {develop_sec.display_name} "
-                        f"(production #{develop_sec_id}) for develop.")
+                        f"({ship.name_jp}) for develop.")
                 else:
-                    develop_sec_id = develop_sec
-                    Log.log_msg(f"Switching to {develop_sec_id} for develop.")
+                    ship = shp.ships.get_ship_from_production_id(develop_sec)
+                    if ship is None:
+                        return False
+                    
+                    Log.log_msg(f"Switching to {ship.name_jp} for develop.")
                 ssw.ship_switcher.current_page = 1
-                ssw.ship_switcher.switch_slot_by_id(1, develop_sec_id)
+                ssw.ship_switcher.switch_slot(1, ship)
             elif context == 'factory_build':
                 build_sec = cfg.config.factory.build_secretary
                 if isinstance(build_sec, ShipTypeEnum):
                     ship = shp.ships.get_highest_level_ship_by_type(build_sec)
                     if ship is None:
                         return False
-                    build_sec_id = ship.production_id
                     Log.log_msg(
                         f"Switching to highest level {build_sec.display_name} "
-                        f"(production #{build_sec_id}) for construction.")
+                        f"({ship.name_jp}) for construction.")
                 else:
-                    build_sec_id = build_sec
-                    Log.log_msg(f"Switching to {build_sec_id} for construction.")
+                    ship = shp.ships.get_ship_from_production_id(build_sec)
+                    if ship is None:
+                        return False
+                    
+                    Log.log_msg(f"Switching to {ship.name_jp} for construction.")
                 ssw.ship_switcher.current_page = 1
-                ssw.ship_switcher.switch_slot_by_id(1, build_sec_id)
+                ssw.ship_switcher.switch_slot(1, ship)
         elif preset_id == None:
             Log.log_debug_1(f"Fleet switch disabled.")
         else:
@@ -224,7 +228,6 @@ class FleetSwitcherCore(object):
             ship_list(fleetcore_obj): ships to use
         """
         
-        EMPTY = -1
         retry = 0
 
         while True:
@@ -249,16 +252,16 @@ class FleetSwitcherCore(object):
             retry = False
             for i in range(1,size + 1):
                 if i > costom_fleet.size:
-                    id = EMPTY #remove this slot
+                    ship = None
                 else:
-                    id = costom_fleet.ship_ids[i-1]
+                    ship = shp.ships.get_ship_from_production_id(costom_fleet.ship_ids[i-1])
 
                 if i <= len(flt.fleets.fleets[flt.fleets.ACTIVE_FLEET_KEY][fleet_id].ship_ids) and \
-                    id == flt.fleets.fleets[flt.fleets.ACTIVE_FLEET_KEY][fleet_id].ship_ids[i-1]:
+                    shp.ships.is_same_ship(ship, flt.fleets.fleets[flt.fleets.ACTIVE_FLEET_KEY][fleet_id].ships[i-1]):
                     Log.log_debug_1("Ship already loaded for custom fleet.")
                     continue
                 
-                if not ssw.ship_switcher.switch_slot_by_id(i-empty_slot_count,id):
+                if not ssw.ship_switcher.switch_slot(i-empty_slot_count, ship):
                     #fleet data update
                     if any_vaild_switch == True:
                         Log.log_msg(f"Retrying...")
@@ -272,7 +275,7 @@ class FleetSwitcherCore(object):
                 else:
                     any_vaild_switch = True
                     
-                if id == EMPTY:
+                if ship == None:
                     empty_slot_count += 1
 
             if retry == True:
@@ -428,7 +431,7 @@ class FleetSwitcherCore(object):
             
             Log.log_msg(f'Ship {ship.name} is not in any fleet, unload from idle fleet')
             for k, idle_ship in enumerate(ships_to_check):
-                if ship.production_id == idle_ship.production_id:
+                if shp.ships.is_same_ship(ship, idle_ship):
                     idx = k
                     break
             ssw.ship_switcher.select_replacement_row(row_idx=idx, ship=ship, mode= ssw.ship_switcher.EQUIPMENT_SHIP_MODE)

--- a/kcauto/fleet_switcher/fleet_switcher_core.py
+++ b/kcauto/fleet_switcher/fleet_switcher_core.py
@@ -147,15 +147,35 @@ class FleetSwitcherCore(object):
                     fleet_id = flt.fleets.get_next_exp_fleet_id(fleet_id)
 
             elif context == 'factory_develop':
-                Log.log_msg(f"Switching to {cfg.config.factory.develop_secretary} for develop.")
-
+                develop_sec = cfg.config.factory.develop_secretary
+                if isinstance(develop_sec, ShipTypeEnum):
+                    ship = shp.ships.get_highest_level_ship_by_type(develop_sec)
+                    if ship is None:
+                        return False
+                    develop_sec_id = ship.production_id
+                    Log.log_msg(
+                        f"Switching to highest level {develop_sec.display_name} "
+                        f"(production #{develop_sec_id}) for develop.")
+                else:
+                    develop_sec_id = develop_sec
+                    Log.log_msg(f"Switching to {develop_sec_id} for develop.")
                 ssw.ship_switcher.current_page = 1
-                ssw.ship_switcher.switch_slot_by_id(1,cfg.config.factory.develop_secretary)
+                ssw.ship_switcher.switch_slot_by_id(1, develop_sec_id)
             elif context == 'factory_build':
-                Log.log_msg(f"Switching to {cfg.config.factory.build_secretary} for construction.")
-
+                build_sec = cfg.config.factory.build_secretary
+                if isinstance(build_sec, ShipTypeEnum):
+                    ship = shp.ships.get_highest_level_ship_by_type(build_sec)
+                    if ship is None:
+                        return False
+                    build_sec_id = ship.production_id
+                    Log.log_msg(
+                        f"Switching to highest level {build_sec.display_name} "
+                        f"(production #{build_sec_id}) for construction.")
+                else:
+                    build_sec_id = build_sec
+                    Log.log_msg(f"Switching to {build_sec_id} for construction.")
                 ssw.ship_switcher.current_page = 1
-                ssw.ship_switcher.switch_slot_by_id(1,cfg.config.factory.build_secretary)
+                ssw.ship_switcher.switch_slot_by_id(1, build_sec_id)
         elif preset_id == None:
             Log.log_debug_1(f"Fleet switch disabled.")
         else:

--- a/kcauto/fleet_switcher/fleet_switcher_core.py
+++ b/kcauto/fleet_switcher/fleet_switcher_core.py
@@ -255,6 +255,8 @@ class FleetSwitcherCore(object):
                     ship = None
                 else:
                     ship = shp.ships.get_ship_from_production_id(costom_fleet.ship_ids[i-1])
+                    if ship is None:
+                        return False
 
                 if i <= len(flt.fleets.fleets[flt.fleets.ACTIVE_FLEET_KEY][fleet_id].ship_ids) and \
                     shp.ships.is_same_ship(ship, flt.fleets.fleets[flt.fleets.ACTIVE_FLEET_KEY][fleet_id].ships[i-1]):

--- a/kcauto/fleet_switcher/fleet_switcher_core.py
+++ b/kcauto/fleet_switcher/fleet_switcher_core.py
@@ -528,8 +528,10 @@ class FleetSwitcherCore(object):
         for i in range(fleet.size):
             
             if fleet.ships[i].equipment_ids == flt.fleets.fleets[flt.fleets.ACTIVE_FLEET_KEY][fleet_id].ships[i].equipment_ids:
-                Log.log_debug_1(f"equipment for ship {load_ship_id[i]} is already loaded")
+                Log.log_msg(f"equipment for ship {fleet.ships[i].name_jp} is already loaded")
                 continue
+            else:
+                Log.log_msg(f"Loading equipment for ship {fleet.ships[i].name_jp}...")                
             
             click_ship_in_equipment_page(i)
 
@@ -588,10 +590,9 @@ class FleetSwitcherCore(object):
                 if row_id == -1:
                     Log.log_error(f"Cannot find equipment {fleet.ships[i].slot_ex.name} \
                         with production id:{fleet.ships[i].slot_ex.production_id}, did you scrapped it?")
-                    
                     exit(1)
                     
-                Log.log_msg(f'Selecting {fleet.ships[i].slot_ex.name} {fleet.ships[i].slot_ex.stars} ★')
+                Log.log_msg(f'Selecting {fleet.ships[i].slot_ex.name} {fleet.ships[i].slot_ex.stars} ★ on page {row_id // 10 + 1} position {(row_id % 10) + 1}')
                 ssw.ship_switcher.select_replacement_row(row_idx=row_id, ship=fleet.ships[i], mode= ssw.ship_switcher.REINFORCEMENT_MODE)
 
                 kca_u.kca.click_existing(

--- a/kcauto/kca_enums/expeditions.py
+++ b/kcauto/kca_enums/expeditions.py
@@ -15,7 +15,7 @@ class ExpeditionEnum(EnumBase):
     E3_17, E3_18, E3_19, E3_20, E3_21, E3_22, E3_23, E3_24 = 17, 18, 19, 20, 21, 22, 23, 24
 
     E4_25, E4_26, E4_27, E4_28, E4_29, E4_30, E4_31, E4_32 = 25, 26, 27, 28, 29, 30, 31, 32
-    E3_D1, E3_D2, E3_D3 = 131, 132, 133 #It is strange but D1: 131 is correct while A1: 100, check api api_mst_mission
+    E5_D1, E5_D2, E5_D3 = 131, 132, 133 #It is strange but D1: 131 is correct while A1: 100, check api api_mst_mission
     E5_33, E5_34, E5_35, E5_36, E5_37, E5_38, E5_39, E5_40 = 33, 34, 35, 36, 37, 38, 39, 40
     E5_E1, E5_E2 = 141, 142  
 

--- a/kcauto/ship_switcher/ship_switcher_core.py
+++ b/kcauto/ship_switcher/ship_switcher_core.py
@@ -9,6 +9,7 @@ import config.config_core as cfg
 import nav.nav as nav
 import ships.equipment_core as equ 
 import ships.ships_core as shp
+from ships.ship import Ship
 import stats.stats_core as sts
 import util.kca as kca_u
 from constants import EXACT, NEAR_EXACT
@@ -37,7 +38,7 @@ class ShipSwitcherCore(object):
             self.rules[slot_id] = ShipSwitchRule(slot_id, slot_rules[slot_id])
 
 
-    def switch_slot_by_id(self, slot, ship_local_id):
+    def switch_slot(self, slot, ship : Ship):
         """
             method to switch a slot to a specified ship
             Args:
@@ -46,26 +47,21 @@ class ShipSwitcherCore(object):
             @todo: track fleet ship_ids using API, not ship_local_id
         """
 
-        # The slot has the specified ship already
-        #@todo upper function has to handle the switched already detection, tho ship switcher does not know what fleet currently is
-        #if len(flt.fleets.fleets[1].ship_ids) >= slot and ship_local_id == flt.fleets.fleets[1].ship_ids[slot-1]:
-            #return
-            
-        if ship_local_id == 0:
+        if ship != None and ship.api_id == 0:
             Log.log_warn("No ship specified to switch in.")
             return False
 
         if not self._select_switch_button(slot):
             return False
 
-        if ship_local_id == -1:
+        if ship == None:
             """Remove ship in this slot"""
             self._select_remove_button()
         else:
-            ship_idx = self._get_ship_idx_by_local_id(ship_local_id)
+            ship_idx = self._get_ship_list_index(ship)
             kca_u.kca.sleep(1)
             self._reset_shiplist()
-            self.select_replacement_row(ship_idx)
+            self.select_replacement_row(ship_idx, ship)
             kca_u.kca.sleep(1)
             if not self._switch_ship():
                 return False
@@ -85,26 +81,8 @@ class ShipSwitcherCore(object):
                 """End the switching process since the slots after this slot are empty"""
                 break
 
-            self.switch_slot_by_id(switch_info["slot_id"], switch_info["ship"].production_id)
-
-            """self._select_switch_button(switch_info["slot_id"])
-            kca_u.kca.sleep(2)
-            self._reset_shiplist()
-            self._select_replacement_ship(switch_info["idx"], switch_info["ship"])
-            kca_u.kca.sleep(2)
-            if self._switch_ship():
-                sts.stats.ship_switcher.ships_switched += 1
-            else:
-                not_fleet_region = Region(
-                    kca_u.kca.game_x + 185,
-                    kca_u.kca.game_y + 210,
-                    330, 450)
-                while not kca_u.kca.exists(
-                    'right', 'shipswitcher|shiplist_button.png'):
-                    kca_u.kca.click(not_fleet_region)
-                    kca_u.kca.sleep(1)
-                return False"""
-
+            self.switch_slot(switch_info["slot_id"], switch_info["ship"])
+            
         """Check if next combat possible, since new ship is switched in"""
         """Refresh home to update ship list"""
         if switch_list:
@@ -153,12 +131,12 @@ class ShipSwitcherCore(object):
             
         return switch_list
 
-    def _get_ship_idx_by_local_id(self, local_id = 0):
+    def _get_ship_list_index(self, ship : Ship):
 
         ship_list = self._local_ships_sorted_by_levels
         
         for i in range(len(ship_list)):
-            if ship_list[i].production_id == local_id:
+            if ship_list[i].production_id == ship.production_id:
                 return i
 
         raise ValueError("Can not find the specified ship")
@@ -235,7 +213,7 @@ class ShipSwitcherCore(object):
                 cached=True)
             kca_u.kca.sleep(0.1)
 
-    def select_replacement_row(self, row_idx, ship : shp.Ship = None, mode = SHIP_MODE):
+    def select_replacement_row(self, row_idx, ship : Ship = None, mode = SHIP_MODE):
         
         """ship_idx // 10 gives 0 when ship_idx < 10, the "if" statement is not needed---XVs32"""
         """target_page = (ship_idx // 10) + 1 if ship_idx > 9 else 1"""
@@ -351,7 +329,7 @@ class ShipSwitcherCore(object):
         return True
 
     @property
-    def _local_ships_sorted_by_levels(self):
+    def _local_ships_sorted_by_levels(self) -> list[Ship]:
         
         temp_list = sorted(shp.ships.ship_pool.values(), key=lambda item: (item.sort_id, item.production_id ))
         temp_list = sorted(
@@ -360,7 +338,7 @@ class ShipSwitcherCore(object):
         return temp_list
 
     @property
-    def _local_ships_sorted_by_class(self):
+    def _local_ships_sorted_by_class(self) -> list[Ship]:
         return sorted(
             [shp.ships.ship_pool[s] for s in shp.ships.ship_pool],
             key=lambda ship: (ship.sort_id, ship.production_id))

--- a/kcauto/ship_switcher/ship_switcher_core.py
+++ b/kcauto/ship_switcher/ship_switcher_core.py
@@ -42,8 +42,8 @@ class ShipSwitcherCore(object):
         """
             method to switch a slot to a specified ship
             Args:
-                slot(int): The slot to switch, index starts from one
-                ship_local_id(int): The target ship production id
+                slot (int): slot number to switch, from 1 to 6, 7 for flagship reinforcement slot
+                ship (Ship): ship to switch in, if None, will remove the ship in this
             @todo: track fleet ship_ids using API, not ship_local_id
         """
 

--- a/kcauto/ship_switcher/ship_switcher_core.py
+++ b/kcauto/ship_switcher/ship_switcher_core.py
@@ -257,7 +257,7 @@ class ShipSwitcherCore(object):
             
         elif mode == self.REINFORCEMENT_MODE:
             self.current_page = 1
-            Log.log_msg(f"Selecting {row_idx}"
+            Log.log_debug_1(f"Selecting {row_idx}"
                         f"(From pg{self.current_page} to pg{target_page}).")
             if ship == None:
                 Log.log_error("Ship must be specified for reinforcement mode.")

--- a/kcauto/ship_switcher/ship_switcher_core.py
+++ b/kcauto/ship_switcher/ship_switcher_core.py
@@ -266,7 +266,7 @@ class ShipSwitcherCore(object):
                 435, 34)
             
         elif mode == self.EQUIPMENT_MODE:
-            Log.log_msg(f"Selecting {row_idx}"
+            Log.log_debug_1(f"Selecting {row_idx}"
                         f"(From pg{self.current_page} to pg{target_page}).")
             
             tot_pages = (len(equ.equipment.equipment_pool[equ.equipment.FREE]) -1) // 10 + 1

--- a/kcauto/ships/ships_core.py
+++ b/kcauto/ships/ships_core.py
@@ -82,6 +82,10 @@ class ShipsCore(object):
 
     def get_ship_from_production_id(self, ship_id) -> Ship:
         
+        if ship_id == 0:
+            Log.log_debug_2("Ship id 0 is requested.")
+            return None
+        
         if ship_id not in self.ship_pool:
             Log.log_error(f"Ship #{ship_id} not found in port.")
             return None

--- a/kcauto/ships/ships_core.py
+++ b/kcauto/ships/ships_core.py
@@ -88,6 +88,16 @@ class ShipsCore(object):
         
         return self.ship_pool[ship_id]
 
+    def get_highest_level_ship_by_type(self, ship_type) -> Ship:
+        ships_of_type = [
+            s for s in self.ship_pool.values()
+            if s.ship_type == ship_type
+        ]
+        if not ships_of_type:
+            Log.log_error(f"No ships of type {ship_type.display_name} found in port.")
+            return None
+        return max(ships_of_type, key=lambda s: s.level)
+
     def create_ship(self, static_data, local_data = Ship.EMPTY_LOCAL_DATA):
         return Ship(static_data, local_data)
      

--- a/kcauto/ships/ships_core.py
+++ b/kcauto/ships/ships_core.py
@@ -118,5 +118,10 @@ class ShipsCore(object):
             Log.log_error(f"Ship {ship_name} #{noro_ship.get('i','Unknown')} not found in ship pool, exiting...")
                 
         return ret
+    
+    def is_same_ship(self, ship1: Ship, ship2: Ship):
+        if ship1 is None or ship2 is None:
+            return False
+        return ship1.production_id == ship2.production_id
 
 ships = ShipsCore()

--- a/kcauto/util/kca.py
+++ b/kcauto/util/kca.py
@@ -1053,9 +1053,13 @@ class Kca(object):
         Args:
             subpage (string): The name of sub page to open. (ex. flowchart)
         """
-        asyncio.get_event_loop().run_until_complete(self.get_html(f"chrome-extension://{self.kc3_id}/pages/strategy/strategy.html{subpage}"))
-        #Wait for quest panel finish closing
-        self.find_kancolle()
+        try:
+            asyncio.get_event_loop().run_until_complete(self.get_html(f"chrome-extension://{self.kc3_id}/pages/strategy/strategy.html{subpage}"))
+            #Wait for quest panel finish closing
+            self.find_kancolle()
+        except Exception as e:
+            Log.log_warn(f"KC3 strategy page unavailable: {e}")
+            self.html = None
 
         return
     
@@ -1071,6 +1075,10 @@ class Kca(object):
             return qst.quest._quest_dom_cache
         
         self.reload_kc3_strategy_page(subpage = "#flowchart")
+
+        if self.html is None:
+            Log.log_warn("KC3 unavailable; quest DOM cache not updated, falling back to config defaults.")
+            return None
 
         dom = PyQuery(self.html, parser='html')
 
@@ -1095,6 +1103,10 @@ class Kca(object):
         target_quest_name = target_quest.name
         
         quest_tree_dom = self.get_quest_dom()
+
+        if quest_tree_dom is None:
+            Log.log_warn(f"KC3 unavailable; cannot get quest count for {target_quest_name}, using config defaults.")
+            return None
         
         i = 0
         while True:

--- a/kcauto/util/kca.py
+++ b/kcauto/util/kca.py
@@ -1088,7 +1088,7 @@ class Kca(object):
         
         return qst.quest._quest_dom_cache
         
-    def get_quest_count(self, target_quest: Quest) -> dict[MapEnum, int]:
+    def get_quest_count(self, target_quest: Quest) -> dict[MapEnum, int] | None:
         """ method to get the remaining action needed for the specified quest.
             For example, the remaining sorties needed for quest Bm3 could be {1-4:1, 3-5:0}
 
@@ -1097,7 +1097,7 @@ class Kca(object):
         
         Return:
             dict with key of quest name, and value of remaining actions needed.
-            return None if quest is not combat type.
+            return None if quest is not combat type, KC3 is unavailable, or quest count cannot be read.
         """
         
         target_quest_name = target_quest.name

--- a/template/data/factory/develop_recipe_preset.json
+++ b/template/data/factory/develop_recipe_preset.json
@@ -1,1 +1,92 @@
-{}
+{
+    "radar": {
+        "factory.develop_recipe": [
+            10,
+            10,
+            250,
+            250
+        ],
+        "factory.develop_secretary": "CV",
+        "comment": "Radar recipe. CV secretary recommended."
+    },
+    "91 & 三式": {
+        "factory.develop_recipe": [
+            10,
+            90,
+            90,
+            30
+        ],
+        "factory.develop_secretary": "BB",
+        "comment": "Type 91 AP shell & Type 3 shell. BB secretary."
+    },
+    "463 砲": {
+        "factory.develop_recipe": [
+            10,
+            251,
+            250,
+            10
+        ],
+        "factory.develop_secretary": "BB",
+        "comment": "46cm gun recipe. Yamato class recommended."
+    },
+    "発煙装置": {
+        "factory.develop_recipe": [
+            10,
+            10,
+            10,
+            10
+        ],
+        "factory.develop_secretary": "DD",
+        "comment": "Smoke generator. DD secretary required."
+    },
+    "大発": {
+        "factory.develop_recipe": [
+            10,
+            10,
+            10,
+            10
+        ],
+        "factory.develop_secretary": "LHA",
+        "comment": "Landing craft. LHA secretary required."
+    },
+    "anti-sub": {
+        "factory.develop_recipe": [
+            10,
+            30,
+            10,
+            31
+        ],
+        "factory.develop_secretary": "DD",
+        "comment": "Anti-submarine equipment. DD secretary."
+    },
+    "plane all": {
+        "factory.develop_recipe": [
+            20,
+            60,
+            10,
+            110
+        ],
+        "factory.develop_secretary": "CV",
+        "comment": "General aircraft recipe. CV secretary."
+    },
+    "Fighter": {
+        "factory.develop_recipe": [
+            20,
+            20,
+            10,
+            90
+        ],
+        "factory.develop_secretary": "CV",
+        "comment": "Fighter aircraft recipe. CV secretary."
+    },
+    "LBAA": {
+        "factory.develop_recipe": [
+            240,
+            260,
+            10,
+            250
+        ],
+        "factory.develop_secretary": "CV",
+        "comment": "Land-based attack aircraft recipe. CV secretary."
+    }
+}


### PR DESCRIPTION
- [x] Fix `recipe_y_offset` rendering: skip `recipe_idx < recipe_y_offset`, draw at `recipe_idx - recipe_y_offset`, highlight at `row + 2`
- [x] Fix DOWN handler: advance cursor in visible area or scroll (`recipe_y_offset += 1`) when at bottom
- [x] Fix UP handler: remove broken `max(recipe_y_offset, ...)` that never scrolled up
- [x] Fix LEFT handler: restore cursor to row `2` (first visible) instead of `2 - recipe_y_offset`
- [x] Fix Enter handler: `preset_idx = curser[CURSER_Y] - 2 + recipe_y_offset` to load correct preset when scrolled
- [x] Hover comment index already correct (applied in prior commit by @XVs32)
- [x] Fix `get_quest_count` return type annotation: `dict[MapEnum, int] | None` and update docstring to describe all `None` return paths