### PR TITLE
Fix a repair flow bug where equipment is not unloaded when buckets are insufficient, which can block later tasks

### DIFF
--- a/kcauto/repair/repair_core.py
+++ b/kcauto/repair/repair_core.py
@@ -114,6 +114,14 @@ class RepairCore(object):
             elif ship in flt.fleets.combat_ships and (com.combat.enabled or pvp.pvp.enabled):
                 
                 if ship.damage >= cfg.config.combat.repair_limit:
+                    if not self._bucket_threshold():
+                        if ship.has_equipment():
+                            if not in_equipment_page:
+                                in_equipment_page = True
+                                equ.equipment.goto()
+
+                            fsw.fleet_switcher.unload_ship(ship)
+                    
                     idx_of_combat_ships[idx] = ship
                     count += 1
                     


### PR DESCRIPTION
#### What

* `RepairCore.repair_ship()` did not check `_bucket_threshold()` before entering the repair flow, so ships could proceed into repair without unloading equipment first in the low-bucket condition.
* As a result, when other tasks needed to manipulate equipment, `FleetSwitcherCore.unload_ship()` could hit the `api_result == {}` branch and fail.

#### How

* Add a `_bucket_threshold()` check in `RepairCore.repair_ship()`.

#### Result

* When bucket levels are below the threshold, ships with equipment are now moved to the equipment page and unloaded before being sent to repair.
* This prevents later tasks from getting stuck or failing in `FleetSwitcherCore.unload_ship()` when equipment operations are required.

#### Reference
