### PR TITLE
Changes click interval in kca._chrome_driver_click_method to prevent long-press detection

### DIFF
--- a/kcauto/util/kca.py
+++ b/kcauto/util/kca.py
@@ -957,7 +957,7 @@ class Kca(object):
         self.visual_hook.Input.dispatchMouseEvent(type = "mouseMoved", x= x + offset_x , y=y + offset_y)
         self.sleep()
         self.visual_hook.Input.dispatchMouseEvent(type = "mousePressed", x= x + offset_x , y=y + offset_y, clickCount = 1, button = "left")
-        self.sleep()
+        self.sleep(0.1, 0.2)
         self.visual_hook.Input.dispatchMouseEvent(type = "mouseReleased", x= x + offset_x , y=y + offset_y, clickCount = 1, button = "left")
         self.sleep()
 


### PR DESCRIPTION
* Change the interval between ```mousePressed``` and ```mouseReleased``` to 0.1–0.2 seconds.