### PR TITLE
Correct browser offset calculation for Windows multi-monitor layouts

### DIFF
--- a/kcauto/util/kca.py
+++ b/kcauto/util/kca.py
@@ -222,8 +222,13 @@ class Kca(object):
                 if max_val < 0.9:
                     raise ValueError(f"Match value {max_val} is below threshold")
                     
-                self.css_x = max_loc[0] - start_x
-                self.css_y = max_loc[1] - start_y
+                # whole-screen origin + whole-screen reference offset - browser reference offset
+                self.css_x = whole_screen_region.x + max_loc[0] - start_x
+                self.css_y = whole_screen_region.y + max_loc[1] - start_y
+                Log.log_debug_1(f"max_loc[0]: {max_loc[0]}")
+                Log.log_debug_1(f"max_loc[1]: {max_loc[1]}")
+                Log.log_debug_1(f"start_x: {start_x}")
+                Log.log_debug_1(f"start_y: {start_y}")
                 Log.log_success(f"Browser offset found at X: {self.css_x}, Y: {self.css_y}")
                 return True
                 


### PR DESCRIPTION
* Include the whole-screen origin when calculating `kca.css_x` and `kca.css_y`
* Add debug logs for reference point and offset calculations