### PR TITLE
Fix LBAS state switching timeout and fatigue handling

### DIFF
--- a/kcauto/combat/lbas_core.py
+++ b/kcauto/combat/lbas_core.py
@@ -195,7 +195,6 @@ class LBASCore(object):
             kca_u.kca.r["top"].hover()
             kca_u.kca.wait("upper_right", f"combat|lbas_group_mode_{next_name}.png")
             kca_u.kca.sleep(0.5)
-        api.api.update_from_api({KCSAPIEnum.SORTIE_ASSIGN_LBAS})
 
     @property
     def assignable_lbas_groups(self):

--- a/kcauto/combat/lbas_group.py
+++ b/kcauto/combat/lbas_group.py
@@ -31,7 +31,7 @@ class LBASGroup(object):
     def needs_rest(self):
         if not self.is_active or not cfg.config.combat.check_lbas_fatigue:
             return False
-        if self.highest_fatigue > LBASFatigueEnum.NO_FATIGUE:
+        if self.highest_fatigue > LBASFatigueEnum.NORMAL_FATIGUE:
             return True
         return False
 


### PR DESCRIPTION
* Remove the incorrect wait for `KCSAPIEnum.SORTIE_ASSIGN_LBAS` from `LBASCore._set_to_desired_state()`.
* Update `LBASGroup.needs_rest` so that only fatigue states higher than `NORMAL_FATIGUE` require rest.