### PR TITLE
Add native POI interaction mode using Electron APIs

### DIFF
--- a/kcauto/api/api_core.py
+++ b/kcauto/api/api_core.py
@@ -203,6 +203,8 @@ class ApiWrapper(object):
         return results
 
     def _check_for_chrome_crash(self):
+        if kca_u.kca.api_hook is None:
+            return
         visual_events = kca_u.kca.api_hook.pop_messages()
         for event in visual_events:
             if event["method"] == "Inspector.targetCrashed":

--- a/kcauto/api/api_listener.py
+++ b/kcauto/api/api_listener.py
@@ -19,6 +19,8 @@ class PoiWebhookServer:
         self.server_thread: Optional[threading.Thread] = None
 
     def set_port(self, port: int):
+        if self.server is not None and port != self.port:
+            raise RuntimeError("Cannot change POI API port while the server is running")
         self.port = port
 
     def set_filter(self, filter_function: Callable[[str, Dict[str, Any]], bool]):
@@ -112,16 +114,27 @@ class PoiWebhookServer:
             def log_message(self, format, *args):
                 pass
 
-        self.server = HTTPServer(("", self.port), WebhookHandler)
+        self.server = HTTPServer(("127.0.0.1", self.port), WebhookHandler)
         Log.log_success(f"Webhook server started, listening on Port {self.port}...")
         self.server.serve_forever()
 
     def start(self):
         """Start the HTTP server in a background daemon thread to avoid blocking the main thread"""
+        if self.server_thread is not None and self.server_thread.is_alive():
+            return
         self.server_thread = threading.Thread(
             target=self._start_http_server, daemon=True
         )
         self.server_thread.start()
+
+    def stop(self):
+        """Stop the HTTP server and release its loopback port."""
+        if self.server is None:
+            return
+        self.server.shutdown()
+        self.server.server_close()
+        self.server = None
+        self.server_thread = None
 
 
 api_listener = PoiWebhookServer()

--- a/kcauto/config/general.py
+++ b/kcauto/config/general.py
@@ -3,6 +3,7 @@ from kca_enums.interaction_modes import InteractionModeEnum
 from constants import (
     DEFAULT_CHROME_DEV_PORT,
     DEFAULT_POI_API_PORT,
+    DEFAULT_POI_CONTROL_PORT,
     MIN_JST_OFFSET,
     MAX_JST_OFFSET,
     MIN_PORT,
@@ -15,14 +16,16 @@ class ConfigGeneral(ConfigBase):
     _interaction_mode = None
     _chrome_dev_port = DEFAULT_CHROME_DEV_PORT
     _poi_api_port = DEFAULT_POI_API_PORT
+    _poi_control_port = DEFAULT_POI_CONTROL_PORT
     _debug_mode = False
 
     def __init__(self, config):
         super().__init__(config)
         self.jst_offset = config["general.jst_offset"]
         self.interaction_mode = config["general.interaction_mode"]
-        self.chrome_dev_port = config["general.chrome_dev_port"]
-        self.poi_api_port = config["general.poi_api_port"]
+        self.chrome_dev_port = config.get("general.chrome_dev_port")
+        self.poi_api_port = config.get("general.poi_api_port")
+        self.poi_control_port = config.get("general.poi_control_port")
 
     @property
     def jst_offset(self):
@@ -56,6 +59,7 @@ class ConfigGeneral(ConfigBase):
     def chrome_dev_port(self, value):
         if value is None:
             self._chrome_dev_port = DEFAULT_CHROME_DEV_PORT
+            return
         elif type(value) is not int or not MIN_PORT <= value <= MAX_PORT:
             raise ValueError("Invalid Chrome Dev Port")
         self._chrome_dev_port = value
@@ -68,6 +72,20 @@ class ConfigGeneral(ConfigBase):
     def poi_api_port(self, value):
         if value is None:
             self._poi_api_port = DEFAULT_POI_API_PORT
+            return
         elif type(value) is not int or not MIN_PORT <= value <= MAX_PORT:
             raise ValueError("Invalid POI API Port")
         self._poi_api_port = value
+
+    @property
+    def poi_control_port(self):
+        return self._poi_control_port
+
+    @poi_control_port.setter
+    def poi_control_port(self, value):
+        if value is None:
+            self._poi_control_port = DEFAULT_POI_CONTROL_PORT
+            return
+        elif type(value) is not int or not MIN_PORT <= value <= MAX_PORT:
+            raise ValueError("Invalid POI Control Port")
+        self._poi_control_port = value

--- a/kcauto/constants.py
+++ b/kcauto/constants.py
@@ -33,6 +33,10 @@ DEFAULT_CHROME_DEV_PORT = 9222
 DEFAULT_POI_API_PORT = 9223
 DEFAULT_POI_CONTROL_PORT = 38591
 API_URL = "https://play.games.dmm.com/game/kancolle"
+API_URLS = (
+    API_URL,
+    "https://ooi.moe/poi",
+)
 POI_URL_POSTFIX = "resources/app.asar/index.html"
 
 # similarity presets

--- a/kcauto/constants.py
+++ b/kcauto/constants.py
@@ -31,6 +31,7 @@ CONTEXT_AUTO_PVP = 8
 # chrome hook url targets
 DEFAULT_CHROME_DEV_PORT = 9222
 DEFAULT_POI_API_PORT = 9223
+DEFAULT_POI_CONTROL_PORT = 38591
 API_URL = "https://play.games.dmm.com/game/kancolle"
 POI_URL_POSTFIX = "resources/app.asar/index.html"
 

--- a/kcauto/kca_enums/interaction_modes.py
+++ b/kcauto/kca_enums/interaction_modes.py
@@ -4,6 +4,7 @@ from kca_enums.enum_base import EnumBase
 class InteractionModeEnum(EnumBase):
     DIRECT_CONTROL = "direct_control"
     CHROME_DRIVER = "chrome_driver"
+    POI = "poi"
 
     @property
     def display_name(self):

--- a/kcauto/startup/kcauto.py
+++ b/kcauto/startup/kcauto.py
@@ -39,6 +39,7 @@ class Kcauto(object):
 
     def __init__(self):
         atexit.register(kca_u.kca.save_screenshots)
+        atexit.register(kca_u.kca.close)
         kca_u.kca.hook_chrome()
 
     def start_kancolle(self):

--- a/kcauto/util/kca.py
+++ b/kcauto/util/kca.py
@@ -5,6 +5,7 @@ import re
 import glob
 from pyquery import PyQuery
 import PyChromeDevTools
+from PIL import Image
 from datetime import datetime, timedelta
 from util.pyvisauto import Region, FindFailed, ImageMatch
 from random import randint, uniform
@@ -37,6 +38,7 @@ import util.coordinate_system as coordinate_system
 import util.click_tracker as clt
 from util.exceptions import ChromeCrashException
 from util.logger import Log
+from util.poi_client import PoiClient, PoiClientError
 
 import asyncio
 from pyppeteer import connect
@@ -48,6 +50,7 @@ class Kca(object):
     ASSETS_FOLDER = "assets"
     api_hook = None
     poi_hook = None
+    poi_client = None
 
     html = None
 
@@ -89,6 +92,11 @@ class Kca(object):
         Raises:
             Exception: could not find Kancolle tabs in Chrome.
         """
+        if cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            return self.hook_poi()
+
+        Region.default_bounds = None
+        ImageMatch.override_capture_method = None
         Log.log_msg("Hooking into Chrome.")
         self.cdt_init(target="api")
         self.cdt_init(target="poi")
@@ -124,6 +132,34 @@ class Kca(object):
 
         coordinate_system.coor.find_game_window_offset()
 
+    def hook_poi(self):
+        """Connect to POI's loopback interaction service without CDP."""
+        Log.log_msg("Connecting to the POI interaction service.")
+        api_listener.api_listener.set_port(cfg.config.general.poi_api_port)
+        api_listener.api_listener.start()
+
+        if self.poi_client is not None:
+            self.poi_client.close()
+        self.poi_client = PoiClient(port=cfg.config.general.poi_control_port)
+        self.poi_client.connect()
+
+        self.api_hook = None
+        self.poi_hook = None
+        coordinate_system.coor.api_hook = None
+        coordinate_system.coor.viewport_x = 0
+        coordinate_system.coor.viewport_y = 0
+        coordinate_system.coor.game_x = 0
+        coordinate_system.coor.game_y = 0
+        coordinate_system.coor._update_regions()
+
+        Region.default_bounds = (0, 0, GAME_W, GAME_H)
+        ImageMatch.override_capture_method = self._poi_capture_method
+        ImageMatch.override_click_method = self._override_click_method
+        ImageMatch.override_hover_method = self._override_hover_method
+        ImageMatch.override_scroll_method = self._override_scroll_method
+        Log.log_success("Connected to POI")
+        return True
+
     def hook_health_check(self):
         """Method that runs through the different events reported to the api
         and visual hooks to ascertain whether or not the tab has crashed or
@@ -132,6 +168,15 @@ class Kca(object):
         Raises:
             ChromeCrashException: Chrome tab crash was detected.
         """
+        if cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            try:
+                if self.poi_client is None or not self.poi_client.health_check():
+                    raise PoiClientError("POI health check failed")
+            except (OSError, PoiClientError):
+                Log.log_warn("POI interaction connection is stale. Reconnecting.")
+                self.hook_poi()
+            return
+
         api_events = self.api_hook.pop_messages()
         for event in api_events:
             if event["method"] == "Inspector.detached":
@@ -217,7 +262,7 @@ class Kca(object):
             ImageMatch.click_callback = clt.click_tracker.track_click
 
         # define click and hover method overrides as needed
-        if cfg.config.general.interaction_mode is InteractionModeEnum.CHROME_DRIVER:
+        if cfg.config.general.interaction_mode in (InteractionModeEnum.CHROME_DRIVER, InteractionModeEnum.POI):
             ImageMatch.override_click_method = self._override_click_method
             ImageMatch.override_hover_method = self._override_hover_method
             ImageMatch.override_scroll_method = self._override_scroll_method
@@ -234,7 +279,11 @@ class Kca(object):
             coordinate_system.coor.game_y = new_game_y
             coordinate_system.coor._update_regions()
 
-        coordinate_system.coor.find_game_window_offset()
+        if cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            coordinate_system.coor.viewport_x = 0
+            coordinate_system.coor.viewport_y = 0
+        else:
+            coordinate_system.coor.find_game_window_offset()
 
         return True
 
@@ -408,6 +457,8 @@ class Kca(object):
             r.hover()
         elif cfg.config.general.interaction_mode is InteractionModeEnum.CHROME_DRIVER:
             self._chrome_driver_hover_method(r)
+        elif cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            r.hover()
 
         self.sleep()
 
@@ -451,6 +502,8 @@ class Kca(object):
             r.click(pad=pad)
         elif cfg.config.general.interaction_mode is InteractionModeEnum.CHROME_DRIVER:
             self._chrome_driver_click_method(r, pad)
+        elif cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            r.click(pad=pad)
 
         self.sleep()
 
@@ -503,6 +556,8 @@ class Kca(object):
             r.scroll(pad=pad, direction=direction, amount=amount)
         elif cfg.config.general.interaction_mode is InteractionModeEnum.CHROME_DRIVER:
             self._chrome_driver_scroll_method(r, pad, direction, amount)
+        elif cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            r.scroll(pad=pad, direction=direction, amount=amount)
 
         self.sleep()
 
@@ -577,6 +632,8 @@ class Kca(object):
 
         elif cfg.config.general.interaction_mode is InteractionModeEnum.CHROME_DRIVER:
             self._chrome_driver_drag_method(r_a, pad, r_b, pad)
+        elif cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            self._poi_drag_method(r_a, pad, r_b, pad)
 
         self.sleep()
 
@@ -754,7 +811,10 @@ class Kca(object):
             x (int): x-coordinate of click generated by pyvisauto
             y (int): y-coordinate of click generated by pyvisauto
         """
-        self._chrome_driver_hover_method(r)
+        if cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            self._poi_hover_method(r, x, y)
+        else:
+            self._chrome_driver_hover_method(r)
 
     def _override_click_method(self, r, x, y, pad):
         """Click method override used when using Chrome Driver interaction
@@ -766,7 +826,10 @@ class Kca(object):
             y (int): y-coordinate of click generated by pyvisauto
             pad (tuple): padding parameter used to modify click coordinate
         """
-        self._chrome_driver_click_method(r, pad)
+        if cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            self._poi_click_method(r, x, y)
+        else:
+            self._chrome_driver_click_method(r, pad)
 
     def _override_scroll_method(self, r, x, y, pad, direction, amount):
         """Scroll method override used when using Chrome Driver interaction
@@ -780,7 +843,70 @@ class Kca(object):
             direction (ScrollDirectionEnum): Scroll direction.
             amount (int): Number of scroll steps to perform.
         """
-        self._chrome_driver_scroll_method(r, pad, direction, amount)
+        if cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            self._poi_scroll_method(r, x, y, direction, amount)
+        else:
+            self._chrome_driver_scroll_method(r, pad, direction, amount)
+
+    def _poi_capture_method(self, region):
+        """Capture and crop a logical game region through the POI plugin."""
+        if self.poi_client is None:
+            raise PoiClientError("POI interaction service is not connected")
+
+        image = self.poi_client.capture()
+        if image.size != (GAME_W, GAME_H):
+            image = image.resize((GAME_W, GAME_H), Image.Resampling.LANCZOS)
+
+        game_x = self.game_x or 0
+        game_y = self.game_y or 0
+        left = int(region.x - game_x)
+        top = int(region.y - game_y)
+        right = left + int(region.w)
+        bottom = top + int(region.h)
+        return image.crop((left, top, right, bottom))
+
+    def _poi_click_method(self, r, x, y):
+        """Dispatch a logical game click through the POI plugin."""
+        self.poi_client.click(x - (self.game_x or 0), y - (self.game_y or 0))
+        r._captured = None
+
+    def _poi_hover_method(self, r, x, y):
+        """Dispatch a logical game hover through the POI plugin."""
+        self.poi_client.hover(x - (self.game_x or 0), y - (self.game_y or 0))
+
+    def _poi_scroll_method(self, r, x, y, direction, amount=1):
+        """Dispatch logical game wheel input through the POI plugin."""
+        if amount < 1:
+            raise ValueError(f"Unsupported scroll amount: {amount}")
+
+        if direction is ScrollDirectionEnum.UP:
+            delta_y = -120
+        elif direction is ScrollDirectionEnum.DOWN:
+            delta_y = 120
+        else:
+            raise ValueError(f"Unsupported scroll direction: {direction}")
+
+        logical_x = x - (self.game_x or 0)
+        logical_y = y - (self.game_y or 0)
+        for _ in range(amount):
+            self.poi_client.scroll(logical_x, logical_y, delta_y)
+            self.sleep()
+        r._captured = None
+
+    def _poi_drag_method(self, r_a, pad_a, r_b, pad_b):
+        """Dispatch a logical game drag through the POI plugin."""
+        start_x = randint(r_a.x + pad_a[0], r_a.x + r_a.w + pad_a[2])
+        start_y = randint(r_a.y + pad_a[1], r_a.y + r_a.h + pad_a[3])
+        end_x = randint(r_b.x + pad_b[0], r_b.x + r_b.w + pad_b[2])
+        end_y = randint(r_b.y + pad_b[1], r_b.y + r_b.h + pad_b[3])
+        self.poi_client.drag(
+            start_x - (self.game_x or 0),
+            start_y - (self.game_y or 0),
+            end_x - (self.game_x or 0),
+            end_y - (self.game_y or 0),
+        )
+        r_a._captured = None
+        r_b._captured = None
 
     def _chrome_driver_click_method(self, r, pad):
         """Click method used in Chrome Driver interaction mode.
@@ -970,7 +1096,6 @@ class Kca(object):
         """
 
         port = cfg.config.general.chrome_dev_port
-        chrome = PyChromeDevTools.ChromeInterface(host="localhost", port=port)
         if target == "api":
             self.api_hook = PyChromeDevTools.ChromeInterface(host=host, port=port)
             coordinate_system.coor.api_hook = self.api_hook
@@ -1119,6 +1244,13 @@ class Kca(object):
 
         Log.log_debug_1("get poi quests stats...")
 
+        if cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            try:
+                return self.poi_client.get_quest_stats()
+            except PoiClientError as e:
+                Log.log_error(f"Failed to get poi quests stats: {str(e)}")
+                return {}
+
         js_code = """
         (() => {
             try {
@@ -1185,6 +1317,12 @@ class Kca(object):
                 Log.log_msg(dialog)
             Log.log_warn("Press Enter to continue")
             input()
+
+    def close(self):
+        """Release POI client and webhook resources during shutdown."""
+        if self.poi_client is not None:
+            self.poi_client.close()
+        api_listener.api_listener.stop()
 
 
 kca = Kca()

--- a/kcauto/util/kca.py
+++ b/kcauto/util/kca.py
@@ -22,7 +22,7 @@ import stats.stats_core as sts
 from constants import (
     GAME_W,
     GAME_H,
-    API_URL,
+    API_URLS,
     POI_URL_POSTFIX,
     EXACT,
     DEFAULT,
@@ -105,29 +105,40 @@ class Kca(object):
 
         api_tab = None
         api_tab_id = None
+        api_tab_url = None
         poi_tab = None
         poi_tab_id = None
+
         for n, tab in enumerate(self.api_hook.tabs):
-            if API_URL in tab["url"]:
-                api_tab = n
-                api_tab_id = tab["id"]
             if tab["url"].endswith(POI_URL_POSTFIX):
                 poi_tab = n
                 poi_tab_id = tab["id"]
 
+        # Prefer the direct DMM target when it is available, then fall back to
+        # POI 11's OOI webview target.
+        for target_url in API_URLS:
+            for n, tab in enumerate(self.api_hook.tabs):
+                if target_url in tab["url"]:
+                    api_tab = n
+                    api_tab_id = tab["id"]
+                    api_tab_url = tab["url"]
+                    break
+            if api_tab_id is not None:
+                break
+
+        if api_tab_id is None or poi_tab_id is None:
+            Log.log_error(
+                "No Kantai Collection or POI tab found in Chrome. Shutting down kcauto."
+            )
+            raise Exception("No running Kantai Collection or POI tab found in Chrome.")
+
         self.poi_hook.connect_targetID(poi_tab_id)
         Log.log_debug_1(f"Connected to poi tab ({poi_tab}:{poi_tab_id})")
-
-        if api_tab_id is None or api_tab_id is None:
-            Log.log_error(
-                "No Kantai Collection tab found in Chrome. Shutting down kcauto."
-            )
-            raise Exception("No running Kantai Collection tab found in Chrome.")
 
         self.api_hook.connect_targetID(api_tab_id)
         self.api_hook.Page.enable()
         self.api_hook.Network.enable()
-        Log.log_debug_1(f"Connected to API tab ({api_tab}:{api_tab_id})")
+        Log.log_debug_1(f"Connected to API tab ({api_tab}:{api_tab_id}, {api_tab_url})")
         Log.log_success("Connected to Chrome")
 
         coordinate_system.coor.find_game_window_offset()
@@ -1096,11 +1107,12 @@ class Kca(object):
         """
 
         port = cfg.config.general.chrome_dev_port
+        chrome = PyChromeDevTools.ChromeInterface(host="localhost", port=port)
         if target == "api":
-            self.api_hook = PyChromeDevTools.ChromeInterface(host=host, port=port)
+            self.api_hook = PyChromeDevTools.ChromeInterface(host=host, port=port, suppress_origin=True)
             coordinate_system.coor.api_hook = self.api_hook
         elif target == "poi":
-            self.poi_hook = PyChromeDevTools.ChromeInterface(host=host, port=port)
+            self.poi_hook = PyChromeDevTools.ChromeInterface(host=host, port=port, suppress_origin=True)
         else:
             raise ValueError("Hook target must be either api or poi.")
 

--- a/kcauto/util/poi_client.py
+++ b/kcauto/util/poi_client.py
@@ -1,0 +1,245 @@
+import json
+import socket
+import struct
+import threading
+from typing import Any, Optional
+
+from PIL import Image
+
+
+class PoiClientError(RuntimeError):
+    """Raised when the POI interaction service cannot fulfill a request."""
+
+
+class PoiClient:
+    """Synchronous client for the POI API Forwarder interaction service.
+
+    Packets use a four-byte little-endian payload length followed by a one-byte
+    payload type. JSON packets carry commands and acknowledgements. Frame
+    packets carry a request id, dimensions, channel count, and raw BGRA data.
+    """
+
+    JSON_PACKET = 1
+    FRAME_PACKET = 2
+    MAX_PACKET_SIZE = 64 * 1024 * 1024
+    DEFAULT_TIMEOUT = 10
+
+    def __init__(self, host="127.0.0.1", port=38591):
+        self.host = host
+        self.port = port
+        self._socket: Optional[socket.socket] = None
+        self._receiver: Optional[threading.Thread] = None
+        self._condition = threading.Condition()
+        self._send_lock = threading.Lock()
+        self._responses: dict[int, dict[str, Any]] = {}
+        self._frames: dict[int, tuple[int, int, int, bytes]] = {}
+        self._next_request_id = 1
+        self._receiver_error: Optional[BaseException] = None
+
+    @property
+    def connected(self):
+        return self._socket is not None and self._receiver_error is None
+
+    def connect(self, timeout=DEFAULT_TIMEOUT):
+        self.close()
+        sock = socket.create_connection((self.host, self.port), timeout=timeout)
+        sock.settimeout(None)
+        self._socket = sock
+        self._receiver_error = None
+        self._receiver = threading.Thread(
+            target=self._receive_loop,
+            args=(sock,),
+            daemon=True,
+        )
+        self._receiver.start()
+
+        response = self._request_json("hello", timeout=timeout, protocol=1)
+        if response.get("protocol") != 1:
+            self.close()
+            raise PoiClientError("Unsupported POI interaction protocol")
+        return response
+
+    def close(self):
+        sock = self._socket
+        receiver = self._receiver
+        self._socket = None
+        self._receiver = None
+        if sock is not None:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            sock.close()
+
+        with self._condition:
+            self._responses.clear()
+            self._frames.clear()
+            self._condition.notify_all()
+
+        if receiver is not None and receiver is not threading.current_thread():
+            receiver.join(timeout=1)
+
+    def health_check(self, timeout=3):
+        response = self._request_json("ping", timeout=timeout)
+        return response.get("type") == "pong"
+
+    def capture(self, timeout=DEFAULT_TIMEOUT):
+        request_id = self._send_request("capture")
+        width, height, channels, bitmap = self._wait_for_frame(request_id, timeout)
+        if channels != 4 or len(bitmap) != width * height * channels:
+            raise PoiClientError("POI returned an invalid BGRA frame")
+        return Image.frombytes("RGBA", (width, height), bitmap, "raw", "BGRA").convert(
+            "RGB"
+        )
+
+    def click(self, x, y, timeout=DEFAULT_TIMEOUT):
+        self._request_json("click", timeout=timeout, x=int(x), y=int(y))
+
+    def hover(self, x, y, timeout=DEFAULT_TIMEOUT):
+        self._request_json("hover", timeout=timeout, x=int(x), y=int(y))
+
+    def scroll(self, x, y, delta_y, timeout=DEFAULT_TIMEOUT):
+        self._request_json(
+            "scroll",
+            timeout=timeout,
+            x=int(x),
+            y=int(y),
+            deltaY=int(delta_y),
+        )
+
+    def drag(self, start_x, start_y, end_x, end_y, timeout=DEFAULT_TIMEOUT):
+        self._request_json(
+            "drag",
+            timeout=timeout,
+            startX=int(start_x),
+            startY=int(start_y),
+            endX=int(end_x),
+            endY=int(end_y),
+        )
+
+    def refresh(self, timeout=DEFAULT_TIMEOUT):
+        self._request_json("refresh", timeout=timeout)
+
+    def get_quest_stats(self, timeout=DEFAULT_TIMEOUT):
+        response = self._request_json("quest_stats", timeout=timeout)
+        return response.get("data", {})
+
+    def _request_json(self, command, timeout=DEFAULT_TIMEOUT, **payload):
+        request_id = self._send_request(command, **payload)
+        return self._wait_for_response(request_id, timeout)
+
+    def _send_request(self, command, **payload):
+        with self._condition:
+            request_id = self._next_request_id
+            self._next_request_id += 1
+
+        message = {"id": request_id, "type": command}
+        message.update(payload)
+        self._send_packet(self.JSON_PACKET, json.dumps(message).encode("utf-8"))
+        return request_id
+
+    def _send_packet(self, packet_type, payload):
+        sock = self._socket
+        if sock is None:
+            raise PoiClientError("Not connected to the POI interaction service")
+
+        packet = bytes((packet_type,)) + payload
+        with self._send_lock:
+            try:
+                sock.sendall(struct.pack("<I", len(packet)) + packet)
+            except OSError as exc:
+                self._set_receiver_error(exc)
+                raise PoiClientError("Failed to send a request to POI") from exc
+
+    def _wait_for_response(self, request_id, timeout):
+        with self._condition:
+            ready = self._condition.wait_for(
+                lambda: (
+                    request_id in self._responses
+                    or self._receiver_error is not None
+                    or self._socket is None
+                ),
+                timeout,
+            )
+            if not ready:
+                raise PoiClientError("Timed out waiting for a response from POI")
+            self._raise_receiver_error()
+            response = self._responses.pop(request_id)
+
+        if response.get("type") == "error":
+            raise PoiClientError(response.get("message", "POI request failed"))
+        return response
+
+    def _wait_for_frame(self, request_id, timeout):
+        with self._condition:
+            ready = self._condition.wait_for(
+                lambda: (
+                    request_id in self._frames
+                    or request_id in self._responses
+                    or self._receiver_error is not None
+                    or self._socket is None
+                ),
+                timeout,
+            )
+            if not ready:
+                raise PoiClientError("Timed out waiting for a frame from POI")
+            self._raise_receiver_error()
+            if request_id in self._responses:
+                response = self._responses.pop(request_id)
+                raise PoiClientError(response.get("message", "POI capture failed"))
+            return self._frames.pop(request_id)
+
+    def _raise_receiver_error(self):
+        if self._receiver_error is not None:
+            raise PoiClientError(
+                "POI interaction connection was closed"
+            ) from self._receiver_error
+        if self._socket is None:
+            raise PoiClientError("POI interaction connection was closed")
+
+    def _receive_loop(self, sock):
+        try:
+            while self._socket is sock:
+                size_data = self._receive_exact(sock, 4)
+                packet_size = struct.unpack("<I", size_data)[0]
+                if packet_size < 1 or packet_size > self.MAX_PACKET_SIZE:
+                    raise PoiClientError("POI returned an invalid packet size")
+                packet = self._receive_exact(sock, packet_size)
+                self._handle_packet(packet[0], packet[1:])
+        except Exception as exc:
+            if self._socket is sock:
+                self._set_receiver_error(exc)
+
+    def _receive_exact(self, sock, length):
+        chunks = bytearray()
+        while len(chunks) < length:
+            chunk = sock.recv(length - len(chunks))
+            if not chunk:
+                raise PoiClientError("POI interaction connection was closed")
+            chunks.extend(chunk)
+        return bytes(chunks)
+
+    def _handle_packet(self, packet_type, payload):
+        if packet_type == self.JSON_PACKET:
+            response = json.loads(payload.decode("utf-8"))
+            request_id = int(response["id"])
+            with self._condition:
+                self._responses[request_id] = response
+                self._condition.notify_all()
+            return
+
+        if packet_type == self.FRAME_PACKET:
+            if len(payload) < 13:
+                raise PoiClientError("POI returned an invalid frame header")
+            request_id, width, height, channels = struct.unpack("<IIIB", payload[:13])
+            with self._condition:
+                self._frames[request_id] = (width, height, channels, payload[13:])
+                self._condition.notify_all()
+            return
+
+        raise PoiClientError(f"POI returned unknown packet type {packet_type}")
+
+    def _set_receiver_error(self, error):
+        with self._condition:
+            self._receiver_error = error
+            self._condition.notify_all()

--- a/kcauto/util/pyvisauto.py
+++ b/kcauto/util/pyvisauto.py
@@ -38,6 +38,9 @@ class ImageMatch(ABC):
     # assign the method for overriding the scroll methods to this class
     # variable. Should accept the parameters (region, x, y, pad, direction, amount)
     override_scroll_method = None
+    # assign the method for overriding screenshot capture to this class
+    # variable. Should accept the region and return a PIL.Image.
+    override_capture_method = None
     # assign the callback method for click to this class variable. Should
     # accept the parameters (region, x, y)
     click_callback = None
@@ -55,6 +58,9 @@ class ImageMatch(ABC):
         Returns:
             PIL.Image: object representing captured region.
         """
+        if ImageMatch.override_capture_method:
+            return ImageMatch.override_capture_method(self)
+
         with mss.mss() as sct:
             # Ensure all coordinates are integers and not None
             # MSS uses {'top': y, 'left': x, 'width': w, 'height': h}
@@ -342,6 +348,8 @@ class Region(ImageMatch):
     search within it or to use other ImageMatch public methods.
     """
 
+    default_bounds = None
+
     def __init__(self, x=None, y=None, w=None, h=None):
         """Initialize a Region instance. Leave all parameters blank to create
         a region for the entire screen. Fill in all parameters otherwise.
@@ -359,7 +367,9 @@ class Region(ImageMatch):
                 specified.
         """
         self.MOUSE_MOVE_SPEED = Region.MOUSE_MOVE_SPEED
-        if x is None and y is None and w is None and h is None:
+        if x is None and y is None and w is None and h is None and Region.default_bounds is not None:
+            self.x, self.y, self.w, self.h = Region.default_bounds
+        elif x is None and y is None and w is None and h is None:
             with mss.mss() as sct:
                 screen = sct.monitors[0]
             self.x = screen["left"]

--- a/kcauto/util/recovery.py
+++ b/kcauto/util/recovery.py
@@ -6,6 +6,7 @@ import stats.stats_core as sts
 import expedition.expedition_core as exp
 
 import util.kca as kca_u
+from kca_enums.interaction_modes import InteractionModeEnum
 from util.logger import Log
 
 
@@ -59,7 +60,9 @@ class Recovery(object):
             if cls.recovery_from_chrome_crash(screen, crash_type=1):
                 return True
 
-        visual_events = kca_u.kca.api_hook.pop_messages()
+        visual_events = []
+        if cfg.config.general.interaction_mode is not InteractionModeEnum.POI:
+            visual_events = kca_u.kca.api_hook.pop_messages()
         for event in visual_events:
             if event["method"] == "Inspector.targetCrashed":
                 Log.log_warn("Chrome Crash (Type 2) detected.")
@@ -224,6 +227,9 @@ class Recovery(object):
             pyautogui.press("tab")
             kca_u.kca.sleep(0.5)
             pyautogui.press("space")
+            kca_u.kca.sleep(5)
+        elif cfg.config.general.interaction_mode is InteractionModeEnum.POI:
+            kca_u.kca.poi_client.refresh()
             kca_u.kca.sleep(5)
         else:
             kca_u.kca.api_hook.Page.reload()

--- a/reference/poi_interaction_mode.md
+++ b/reference/poi_interaction_mode.md
@@ -14,4 +14,6 @@ loopback-only and supplies logical 1200x720 game captures, mouse input,
 refresh, and POI quest data. POI mode does not require Chrome's remote
 debugging port and continues to capture the game while its window is covered.
 
-`direct_control` and `chrome_driver` keep their existing behavior.
+`direct_control` and `chrome_driver` keep their existing behavior. The
+`chrome_driver` mode continues to support both the DMM game target and POI's
+`https://ooi.moe/poi` target through port 9222.

--- a/reference/poi_interaction_mode.md
+++ b/reference/poi_interaction_mode.md
@@ -1,0 +1,17 @@
+# POI interaction mode
+
+Set `general.interaction_mode` to `poi` when KanColle runs inside POI. The API
+Forwarder plugin must be enabled with matching ports:
+
+```json
+"general.interaction_mode": "poi",
+"general.poi_api_port": 9223,
+"general.poi_control_port": 38591
+```
+
+The webhook port supplies KCSAPI and map-resource events. The control port is
+loopback-only and supplies logical 1200x720 game captures, mouse input,
+refresh, and POI quest data. POI mode does not require Chrome's remote
+debugging port and continues to capture the game while its window is covered.
+
+`direct_control` and `chrome_driver` keep their existing behavior.

--- a/template/configs/config_cui.json
+++ b/template/configs/config_cui.json
@@ -56,6 +56,7 @@
   "factory.enabled": false,
   "general.chrome_dev_port": 9222,
   "general.poi_api_port": 9223,
+  "general.poi_control_port": 38591,
   "general.interaction_mode": "chrome_driver",
   "general.jst_offset": 0,
   "general.paused": false,

--- a/tests/test_poi_client.py
+++ b/tests/test_poi_client.py
@@ -1,0 +1,125 @@
+import json
+import socket
+import struct
+import sys
+import threading
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "kcauto"))
+
+from config.general import ConfigGeneral  # noqa: E402
+from util.poi_client import PoiClient  # noqa: E402
+
+
+def receive_exact(sock, length):
+    data = bytearray()
+    while len(data) < length:
+        chunk = sock.recv(length - len(data))
+        if not chunk:
+            raise EOFError
+        data.extend(chunk)
+    return bytes(data)
+
+
+def send_packet(sock, packet_type, payload):
+    packet = bytes((packet_type,)) + payload
+    sock.sendall(struct.pack("<I", len(packet)) + packet)
+
+
+class FakePoiServer:
+    def __init__(self):
+        self.commands = []
+        self.socket = socket.socket()
+        self.socket.bind(("127.0.0.1", 0))
+        self.socket.listen(1)
+        self.port = self.socket.getsockname()[1]
+        self.thread = threading.Thread(target=self.run, daemon=True)
+
+    def start(self):
+        self.thread.start()
+
+    def close(self):
+        self.socket.close()
+
+    def run(self):
+        client, _ = self.socket.accept()
+        with client:
+            while True:
+                try:
+                    packet_size = struct.unpack("<I", receive_exact(client, 4))[0]
+                    packet = receive_exact(client, packet_size)
+                except (EOFError, OSError, struct.error):
+                    return
+                command = json.loads(packet[1:].decode("utf-8"))
+                self.commands.append(command)
+                request_id = command["id"]
+
+                if command["type"] == "capture":
+                    bitmap = bytes((0, 0, 255, 255, 0, 255, 0, 255))
+                    frame = struct.pack("<IIIB", request_id, 2, 1, 4) + bitmap
+                    send_packet(client, PoiClient.FRAME_PACKET, frame)
+                    continue
+
+                response = {"id": request_id, "type": "ok"}
+                if command["type"] == "hello":
+                    response.update(type="hello", protocol=1)
+                elif command["type"] == "ping":
+                    response["type"] = "pong"
+                elif command["type"] == "quest_stats":
+                    response.update(type="quest_stats", data={"201": {"state": 2}})
+                send_packet(
+                    client,
+                    PoiClient.JSON_PACKET,
+                    json.dumps(response).encode("utf-8"),
+                )
+
+
+class PoiClientTest(unittest.TestCase):
+    def setUp(self):
+        self.server = FakePoiServer()
+        self.server.start()
+        self.client = PoiClient(port=self.server.port)
+        self.client.connect()
+
+    def tearDown(self):
+        self.client.close()
+        self.server.close()
+
+    def test_protocol_round_trip(self):
+        self.assertTrue(self.client.health_check())
+        image = self.client.capture()
+        self.assertEqual(image.size, (2, 1))
+        self.assertEqual(image.getpixel((0, 0)), (255, 0, 0))
+        self.assertEqual(image.getpixel((1, 0)), (0, 255, 0))
+        self.assertEqual(self.client.get_quest_stats(), {"201": {"state": 2}})
+
+        self.client.click(100.8, 200.2)
+        self.assertEqual(self.server.commands[-1]["x"], 100)
+        self.assertEqual(self.server.commands[-1]["y"], 200)
+
+        self.client.scroll(300.9, 400.1, 120)
+        self.assertEqual(self.server.commands[-1]["type"], "scroll")
+        self.assertEqual(self.server.commands[-1]["deltaY"], 120)
+
+    def test_close_marks_client_disconnected(self):
+        self.client.close()
+        self.assertFalse(self.client.connected)
+
+
+class ConfigGeneralTest(unittest.TestCase):
+    def test_old_config_uses_poi_port_defaults(self):
+        config = ConfigGeneral(
+            {
+                "general.jst_offset": 0,
+                "general.interaction_mode": "poi",
+                "general.chrome_dev_port": 9222,
+            }
+        )
+        self.assertEqual(config.poi_api_port, 9223)
+        self.assertEqual(config.poi_control_port, 38591)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wiki/docs/Ch5.md
+++ b/wiki/docs/Ch5.md
@@ -48,11 +48,12 @@ Controls basic application behavior and browser interaction.
 
 #### `general.interaction_mode`
 - **Type**: string
-- **Valid Values**: `"chrome_driver"`, `"direct_control"`
+- **Valid Values**: `"chrome_driver"`, `"direct_control"`, `"poi"`
 - **Default**: `"chrome_driver"`
 - **Description**: Determines how kcauto interacts with the browser.  
-Chrome driver mode sends control signal to browser directly,  
-while direct control mode control your mouse to interact with browser.
+Chrome driver mode sends control signals through Chrome DevTools, direct
+control mode uses the desktop mouse, and POI mode uses the API Forwarder
+plugin's loopback screenshot and input service.
 
 #### `general.jst_offset`
 - **Type**: integer
@@ -73,6 +74,13 @@ Do not change if you don't know what you're doing.
 - **Default**: 9223
 - **Description**: Port number for POI API forwarding.  
 Do not change if you don't know what you're doing.
+
+#### `general.poi_control_port`
+- **Type**: integer
+- **Valid Range**: 0 to 65535
+- **Default**: 38591
+- **Description**: Loopback port for POI screenshots and input when
+`general.interaction_mode` is `"poi"`.
 
 #### ~~`general.paused`~~ Not working at the moment(2025/07/17)
 - **Type**: boolean


### PR DESCRIPTION
 ## Summary

Add a native `poi` interaction mode that communicates with the companion POI plugin through a loopback protocol.

The companion plugin uses Electron APIs to capture the game view and dispatch mouse input, replacing Chrome DevTools for screenshot and input operations.

## Motivation

The existing POI control path requires POI to be started with a Chrome remote-debugging parameter. It also depends on Chrome DevTools connections for capture and input, which adds setup requirements and may become unreliable when the POI window is covered by other windows on Windows.

The native POI interaction mode:

- Does not require starting POI with a remote-debugging parameter.
- Uses Electron `capturePage` for game-view capture.
- Uses Electron `sendInputEvent` for mouse input.
- Continues operating when the POI window is covered or not focused on Windows.
- Improves capture and input stability.
- Preserves the existing `direct_control` and `chrome_driver` modes.

## Implementation

- Add a `poi` interaction mode and a configurable POI control port.
- Add a synchronous `PoiClient` for the loopback interaction protocol.
- Support capture, click, hover, scroll, drag, refresh, health checks, and quest statistics.
- Route visual capture and mouse operations through the POI plugin in `poi` mode.
- Use fixed 1200×720 logical game coordinates for plugin-backed interaction.
- Keep the existing webhook API forwarding path.
- Add shutdown cleanup and POI connection recovery.
- Add configuration documentation and protocol unit tests.

## Companion plugin

Requires XVs32/poi-plugin-api-forwarder#1.

The companion plugin provides the Electron capture and input service used by this mode.

## Testing

- Python unit tests: 3/3 passed.
- JavaScript syntax checks passed for the companion plugin.
- Verified capture and input while the POI window was covered on Windows.
- Completed continuous POI operation testing for approximately one hour.
- Tested:
  - Sortie and battle-result handling
  - Expedition receive and dispatch
  - Repair and resupply
  - Fatigue waiting
  - Quest activation, completion, reward collection, and successor planning
  - Screenshot, click, hover, scroll, drag, and refresh operations

- Final test stderr was empty.
## Compatibility

The new behavior is only enabled when:

```json
{
  "general.interaction_mode": "poi"
}
```

The existing `direct_control` and `chrome_driver` modes remain available.

## Related

- Closes #293
- Follow-up to #249 and PR #273
- Companion plugin PR: XVs32/poi-plugin-api-forwarder#1